### PR TITLE
Namespace details

### DIFF
--- a/security/production-secure-deploy/README.rst
+++ b/security/production-secure-deploy/README.rst
@@ -64,17 +64,19 @@ RBAC.
 
      helm upgrade --install -f $TUTORIAL_HOME/../../assets/openldap/ldaps-rbac.yaml test-ldap $TUTORIAL_HOME/../../assets/openldap --namespace confluent
 
+Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespace available, otherwise you can create it by running ``kubectl create namespace confluent``. 
+
 #. Validate that OpenLDAP is running:  
    
    ::
 
-     kubectl get pods
+     kubectl get pods -n confluent
 
 #. Log in to the LDAP pod:
 
    ::
 
-     kubectl exec -it ldap-0 -- bash
+     kubectl -n confluent exec -it ldap-0 -- bash
 
 #. Run the LDAP search command:
 

--- a/security/production-secure-deploy/README.rst
+++ b/security/production-secure-deploy/README.rst
@@ -268,7 +268,7 @@ then the internal domain names will be:
 ::
   
   # Create Certificate Authority
-  cfssl gencert -initca $TUTORIAL_HOME/../../assets/certs/ca-csr.json | cfssljson -bare $TUTORIAL_HOME/../../assets/certs/generated/ca -
+  mkdir $TUTORIAL_HOME/../../assets/certs/generated && cfssl gencert -initca $TUTORIAL_HOME/../../assets/certs/ca-csr.json | cfssljson -bare $TUTORIAL_HOME/../../assets/certs/generated/ca -
 
 ::
 


### PR DESCRIPTION
Rolling out this tutorial, I had the following issues :

First one:
```
$ helm upgrade --install -f $TUTORIAL_HOME/../../assets/openldap/ldaps-rbac.yaml test-ldap $TUTORIAL_HOME/../../assets/openldap --namespace confluent
Release "test-ldap" does not exist. Installing it now.
Error: create: failed to create: namespaces "confluent" not found
```

Then:
```
cfssl gencert -initca $TUTORIAL_HOME/../../assets/certs/ca-csr.json | cfssljson -bare $TUTORIAL_HOME/../../assets/certs/generated/ca -                                                                             namespace-details ✱ ◼

2021/05/17 13:30:42 [INFO] generating a new CA key and certificate from CSR
2021/05/17 13:30:42 [INFO] generate received request
2021/05/17 13:30:42 [INFO] received CSR
2021/05/17 13:30:42 [INFO] generating key: rsa-2048
2021/05/17 13:30:42 [INFO] encoded CSR
2021/05/17 13:30:42 [INFO] signed certificate with serial number 573699776245748557103157149119414917932214823682
open /<tutorial directory>/security/production-secure-deploy/../../assets/certs/generated/ca.pem: no such file or directory
```

So I made these changes to move forward.