### PR TITLE
Fix topic's kafkaRest field

### DIFF
--- a/security/production-secure-deploy/topic.yaml
+++ b/security/production-secure-deploy/topic.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 1
   partitionCount: 1
-  kafkaRestRef:
+  kafkaRest:
     authentication:
       type: bearer
       bearer:


### PR DESCRIPTION
From an explain on the resource:

```
KIND:     KafkaTopic
VERSION:  platform.confluent.io/v1beta1

RESOURCE: spec <Object>

DESCRIPTION:
     KafkaTopicSpec defines the desired state of KafkaTopic

FIELDS:
   configs	<map[string]string>
     Configs allows passing configs for topic More information about topic
     configs is available here
     https://docs.confluent.io/current/installation/configuration/topic-configs.html

   kafkaClusterRef	<Object>
     KafkaClusterRef defines the name of the kafka cluster

   kafkaRest	<Object>
     KafkaRestRef defines the Kafka Rest API configuration
...
```