### PR TITLE
updated mds provider type and replaced restProxy with KafkaRest in confluent-platform-production-autogeneratedcerts.yaml

### DIFF
--- a/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
+++ b/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
@@ -55,7 +55,6 @@ spec:
     type: rbac
     superUsers:
     - User:kafka
-    - User:ANONYMOUS
   services:
     mds:
       tls:

--- a/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
+++ b/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
@@ -57,13 +57,6 @@ spec:
     - User:kafka
     - User:ANONYMOUS
   services:
-    restProxy:
-      enabled: true
-      mds:
-        authentication:
-          type: bearer
-          bearer:
-            secretRef: mds-client
     mds:
       tls:
         enabled: true
@@ -74,23 +67,30 @@ spec:
         loadBalancer:
           domain: my.domain
           prefix: rb-mds
-      ldap:
-        address: ldap://ldap.confluent.svc.cluster.local:389
-        authentication:
-          type: simple
-          simple:
-            secretRef: credential
-        configurations:
-          groupNameAttribute: cn
-          groupObjectClass: group
-          groupMemberAttribute: member
-          groupMemberAttributePattern: CN=(.*),DC=test,DC=com
-          groupSearchBase: dc=test,dc=com
-          userNameAttribute: cn
-          userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
-          userObjectClass: organizationalRole
-          userSearchBase: dc=test,dc=com
+      provider: 
+        type: ldap
+        ldap:
+          address: ldap://ldap.confluent.svc.cluster.local:389
+          authentication:
+            type: simple
+            simple:
+              secretRef: credential
+          configurations:
+            groupNameAttribute: cn
+            groupObjectClass: group
+            groupMemberAttribute: member
+            groupMemberAttributePattern: CN=(.*),DC=test,DC=com
+            groupSearchBase: dc=test,dc=com
+            userNameAttribute: cn
+            userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
+            userObjectClass: organizationalRole
+            userSearchBase: dc=test,dc=com
   dependencies:
+    kafkaRest:
+      authentication:
+        type: bearer
+        bearer:
+          secretRef: mds-client
     zookeeper:
       endpoint: zookeeper.confluent.svc.cluster.local:2182
       authentication:
@@ -272,3 +272,15 @@ spec:
       url: https://schemaregistry.confluent.svc.cluster.local:8081
       tls:
         enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestClass
+metadata:
+  name: default
+  namespace: confluent
+spec:
+  kafkaRest:
+    authentication:
+      type: bearer
+      bearer:
+        secretRef: rest-credential

--- a/security/production-secure-deploy/confluent-platform-production-mtls.yaml
+++ b/security/production-secure-deploy/confluent-platform-production-mtls.yaml
@@ -58,13 +58,6 @@ spec:
     superUsers:
     - User:kafka
   services:
-    restProxy:
-      enabled: true
-      mds:
-        authentication:
-          type: bearer
-          bearer:
-            secretRef: mds-client
     mds:
       tls:
         enabled: true
@@ -77,22 +70,22 @@ spec:
           prefix: rb-mds
       provider:
         type: ldap
-      ldap:
-        address: ldap://ldap.confluent.svc.cluster.local:389
-        authentication:
-          type: simple
-          simple:
-            secretRef: credential
-        configurations:
-          groupNameAttribute: cn
-          groupObjectClass: group
-          groupMemberAttribute: member
-          groupMemberAttributePattern: CN=(.*),DC=test,DC=com
-          groupSearchBase: dc=test,dc=com
-          userNameAttribute: cn
-          userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
-          userObjectClass: organizationalRole
-          userSearchBase: dc=test,dc=com
+        ldap:
+          address: ldap://ldap.confluent.svc.cluster.local:389
+          authentication:
+            type: simple
+            simple:
+              secretRef: credential
+          configurations:
+            groupNameAttribute: cn
+            groupObjectClass: group
+            groupMemberAttribute: member
+            groupMemberAttributePattern: CN=(.*),DC=test,DC=com
+            groupSearchBase: dc=test,dc=com
+            userNameAttribute: cn
+            userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
+            userObjectClass: organizationalRole
+            userSearchBase: dc=test,dc=com
   dependencies:
     kafkaRest:
       authentication:


### PR DESCRIPTION
`services.mds.provider.type: ldap` was missing from file [confluent-platform-production-autogeneratedcerts.yaml](https://github.com/confluentinc/confluent-kubernetes-examples/blob/master/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml). 

Also, replaced the restProxy with KafkaRest in confluent-platform-production-autogeneratedcerts.yaml file. 