### PR TITLE
Bug fix for hybrid ControlCenter not showing ksqldb

### DIFF
--- a/hybrid/ccloud-integration/confluent-platform.yaml
+++ b/hybrid/ccloud-integration/confluent-platform.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: platform.confluent.io/v1beta1
 kind: KsqlDB
 metadata:
-  name: ksqldb-tls
+  name: ksqldb
   namespace: confluent
 spec:
   replicas: 1
@@ -99,7 +99,7 @@ spec:
           secretRef: cloud-sr-access
     ksqldb:
     - name: ksql-dev
-      url: http://ksqldb-tls.confluent.svc.cluster.local:8088
+      url: http://ksqldb.confluent.svc.cluster.local:8088
     connect:
     - name: connect-dev
       url:  https://connect.confluent.svc.cluster.local:8083

--- a/hybrid/ccloud-integration/confluent-platform.yaml
+++ b/hybrid/ccloud-integration/confluent-platform.yaml
@@ -59,6 +59,7 @@ spec:
         type: basic
         basic:
           secretRef: cloud-sr-access
+
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: ControlCenter
@@ -98,9 +99,7 @@ spec:
           secretRef: cloud-sr-access
     ksqldb:
     - name: ksql-dev
-      url: https://ksqldb.confluent.svc.cluster.local:8088
-      tls:
-        enabled: true
+      url: http://ksqldb-tls.confluent.svc.cluster.local:8088
     connect:
     - name: connect-dev
       url:  https://connect.confluent.svc.cluster.local:8083


### PR DESCRIPTION
The hybrid scenario does not work for Control Center and the ksqldb integration. 

This is due to: 
We are marking in the C3 CRD that ksqldb has tls, which it doe not. 
We are using the wrong hostname in the URL for ksqldb in the C3 CRD. 


bug fix. 