### PR TITLE
Invalid cpu value

### DIFF
--- a/hybrid/replicator/components-source.yaml
+++ b/hybrid/replicator/components-source.yaml
@@ -8,7 +8,7 @@ spec:
   podTemplate:
     resources:
       requests:
-        cpu: 0.1 # 1
+        cpu: 100m # 1
         memory: 512Mi # 4Gi
   replicas: 3
   image:
@@ -28,7 +28,7 @@ spec:
   podTemplate:
     resources:
       requests:
-        cpu: 0.1 # 1
+        cpu: 100m # 1
         memory: 512Mi # 4Gi
   replicas: 3
   image:


### PR DESCRIPTION
This patch fixes the error `spec.podTemplate.resources.requests.cpu in body must be of type integer: number` when applying this into k8s