### PR TITLE
Update producer-app-data.yaml

### DIFF
--- a/quickstart-deploy/producer-app-data.yaml
+++ b/quickstart-deploy/producer-app-data.yaml
@@ -31,7 +31,7 @@ spec:
         - -c
         - |
           kafka-producer-perf-test \
-            --topic ${HOSTNAME}  \
+            --topic elastic-0  \
             --record-size 64 \
             --throughput 1 \
             --producer.config /mnt/kafka.properties \


### PR DESCRIPTION
Changing to an explicit topic name in the kafka-producer-perf-test command. Currently, using {HOSTNAME} does not work if the number of replicas is greater than 0, and having a topic CRD already hardcoded to elastic-0, it makes sense to have it aligned.