### PR TITLE
Clusterlink demo fix

### DIFF
--- a/assets/certs/component-certs/kafka-server-domain.json
+++ b/assets/certs/component-certs/kafka-server-domain.json
@@ -4,7 +4,11 @@
     "kafka",
     "*.my.domain",
     "kafka.confluent.svc.cluster.local",
-    "*.kafka.confluent.svc.cluster.local"
+    "*.kafka.confluent.svc.cluster.local",
+    "kafka.source.svc.cluster.local",
+    "*.kafka.source.svc.cluster.local",
+    "kafka.destination.svc.cluster.local",
+    "*.kafka.destination.svc.cluster.local"
   ],
   "key": {
     "algo": "rsa",

--- a/assets/certs/component-certs/zookeeper-server-domain.json
+++ b/assets/certs/component-certs/zookeeper-server-domain.json
@@ -3,7 +3,11 @@
   "hosts": [
     "zookeeper",
     "zookeeper.confluent.svc.cluster.local",
-    "*.zookeeper.confluent.svc.cluster.local"
+    "*.zookeeper.confluent.svc.cluster.local",
+    "zookeeper.source.svc.cluster.local",
+    "*.zookeeper.source.svc.cluster.local",
+    "zookeeper.destination.svc.cluster.local",
+    "*.zookeeper.destination.svc.cluster.local"
   ],
   "key": {
     "algo": "rsa",

--- a/hybrid/clusterlink/mtls_source_cluster/clusterlink-mtls.yaml
+++ b/hybrid/clusterlink/mtls_source_cluster/clusterlink-mtls.yaml
@@ -14,7 +14,7 @@ spec:
       type: mtls
     tls:
       enabled: true
-      secretRef: source-tls-group1
+      secretRef: source-tls-secret
     kafkaRestClassRef:
       name: source-kafka-rest
       namespace: source

--- a/hybrid/clusterlink/mtls_source_cluster/zk-kafka-destination.yaml
+++ b/hybrid/clusterlink/mtls_source_cluster/zk-kafka-destination.yaml
@@ -14,7 +14,7 @@ spec:
   authentication:
     type: mtls
   tls:
-    secretRef: destination-tls-group1
+    secretRef: destination-tls-zk1
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Kafka
@@ -25,7 +25,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-server:7.0.0
-    init: confluentinc/confluent-init-containerr:2.2.0
+    init: confluentinc/confluent-init-container:2.2.0
   dataVolumeCapacity: 10Gi
   tls:
     secretRef: destination-tls-group1

--- a/hybrid/clusterlink/mtls_source_cluster/zk-kafka-source.yaml
+++ b/hybrid/clusterlink/mtls_source_cluster/zk-kafka-source.yaml
@@ -14,7 +14,7 @@ spec:
   authentication:
     type: mtls
   tls:
-    secretRef: source-tls-group1
+    secretRef: source-tls-zk1
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Kafka


### PR DESCRIPTION
I was trying to use the clusterlink demo, but ran into a few different issues. After further testing, I found the following changes allowed for a successful cluster link example.

1. Issues with the SSL certificates not containing the Source and Destination entries in the SAN
2. Source and Destination deployment yaml used the same TLS secret for zookeeper and kafka, this would certainly fail SSL.
3. Clusterlink Resource Yaml failed to apply with algo error. Noted here https://confluent.slack.com/archives/CDY2L9V52/p1639753504388300
I worked around this by converting the `kafka-server-key.pem` to PKCS8 format and creating a new TLS secret in kubernetes.
4. Also fixed up a few of the items in the README.md file.