### PR TITLE
Set metrics reporter replication factor to 1

### DIFF
--- a/quickstart-deploy/confluent-platform-singlenode.yaml
+++ b/quickstart-deploy/confluent-platform-singlenode.yaml
@@ -34,6 +34,7 @@ spec:
   configOverrides:
     server:
       - "confluent.license.topic.replication.factor=1"
+      - "confluent.metrics.reporter.topic.replicas=1"
       - "confluent.tier.metadata.replication.factor=1"
       - "confluent.metadata.topic.replication.factor=1"
       - "confluent.balancer.topic.replication.factor=1"
@@ -51,6 +52,8 @@ spec:
       fsGroup: 1000
       runAsUser: 1000
       runAsNonRoot: true
+  metricReporter:
+    enabled: true
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Connect


### PR DESCRIPTION
If `metricReporter.enabled` is set to `true` in the Kafka CR for single node CP deployment, Kafka logs InvalidReplicationFactorException for `_confluent-metrics` topic: 

`org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.`

Set `confluent.metrics.reporter.topic.replicas` to 1 if there is only one Kafka broker in the Kafka metrics cluster.