### PR TITLE
fix namespace from default to confluent

### DIFF
--- a/quickstart-deploy/producer-app-data-singlenode.yaml
+++ b/quickstart-deploy/producer-app-data-singlenode.yaml
@@ -11,6 +11,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elastic
+  namespace: confluent
 spec:
   serviceName: elastic
   podManagementPolicy: Parallel

--- a/quickstart-deploy/producer-app-data.yaml
+++ b/quickstart-deploy/producer-app-data.yaml
@@ -11,6 +11,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elastic
+  namespace: confluent
 spec:
   serviceName: elastic
   podManagementPolicy: Parallel


### PR DESCRIPTION
##Why?

The secret which is created for producer config is in the `confluent` namespace, whereas the producer is in default, so this is to fix the namespace for the producer.

Error encountered:

```
MountVolume.SetUp failed for volume "kafka-properties" : secret "kafka-client-config" not found
```