### PR TITLE
Update confluent-platform-tls-only.yaml

### DIFF
--- a/security/autogenerated-tls_only/confluent-platform-tls-only.yaml
+++ b/security/autogenerated-tls_only/confluent-platform-tls-only.yaml
@@ -153,3 +153,13 @@ spec:
       url: https://schemaregistry.confluent.svc.cluster.local:8081
       tls:
         enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestClass
+metadata:
+  name: default
+  namespace: confluent
+spec:
+  kafkaClusterRef:
+    name: kafka
+    namespace: confluent


### PR DESCRIPTION
deployment fails without creation of the 'default' kafka rest class.