### PR TITLE
Update README.rst

### DIFF
--- a/quickstart-deploy/README.rst
+++ b/quickstart-deploy/README.rst
@@ -203,5 +203,5 @@ Shut down Confluent Platform and the data:
 
 ::
 
-  helm delete confluent-operator
+  helm delete operator
   


### PR DESCRIPTION
The release name is "operator" as per the installation step "helm upgrade --install operator confluentinc/confluent-for-kubernetes"