### PR TITLE
update passwordEncoder and remove confluent.cluster.link.enable config

### DIFF
--- a/hybrid/clusterlink/mtls_source_cluster/README.md
+++ b/hybrid/clusterlink/mtls_source_cluster/README.md
@@ -100,7 +100,7 @@ kubectl -n destination create secret generic rest-credential \
     --from-file=basic.txt=$TUTORIAL_HOME/rest-credential.txt
     
 kubectl -n destination create secret generic password-encoder-secret \
-    --from-file=password_encoder_secret=$TUTORIAL_HOME/password-encoder-secret.txt
+    --from-file=password-encoder.txt=$TUTORIAL_HOME/password-encoder-secret.txt
  
 ```
 #### deploy destination zookeeper and kafka cluster in namespace `destination`

--- a/hybrid/clusterlink/mtls_source_cluster/password-encoder-secret.txt
+++ b/hybrid/clusterlink/mtls_source_cluster/password-encoder-secret.txt
@@ -1,1 +1,1 @@
-secret=secret
+password=secret1

--- a/hybrid/clusterlink/mtls_source_cluster/zk-kafka-destination.yaml
+++ b/hybrid/clusterlink/mtls_source_cluster/zk-kafka-destination.yaml
@@ -56,12 +56,8 @@ spec:
         type: mtls
       tls:
         enabled: true
-  mountedSecrets:
-    - secretRef: password-encoder-secret
-  configOverrides:
-    server:
-      - confluent.cluster.link.enable=true
-      - password.encoder.secret=${file:/mnt/secrets/password-encoder-secret/password_encoder_secret:secret}
+  passwordEncoder:
+    secretRef: password-encoder-secret
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestClass

--- a/hybrid/clusterlink/sasl_ssl_source_cluster/README.md
+++ b/hybrid/clusterlink/sasl_ssl_source_cluster/README.md
@@ -101,7 +101,7 @@ kubectl -n destination create secret generic rest-credential \
     --from-file=basic.txt=$TUTORIAL_HOME/rest-credential.txt
     
 kubectl -n destination create secret generic password-encoder-secret \
-    --from-file=password_encoder_secret=$TUTORIAL_HOME/password-encoder-secret.txt
+    --from-file=password-encoder.txt=$TUTORIAL_HOME/password-encoder-secret.txt
 ```
 
 #### deploy destination zookeeper and kafka cluster in namespace `destination`

--- a/hybrid/clusterlink/sasl_ssl_source_cluster/password-encoder-secret.txt
+++ b/hybrid/clusterlink/sasl_ssl_source_cluster/password-encoder-secret.txt
@@ -1,1 +1,1 @@
-secret=secret
+password=secret1

--- a/hybrid/clusterlink/sasl_ssl_source_cluster/zk-kafka-destination.yaml
+++ b/hybrid/clusterlink/sasl_ssl_source_cluster/zk-kafka-destination.yaml
@@ -50,12 +50,8 @@ spec:
           secretRef: credential
           roles:
             - Administrators
-  mountedSecrets:
-    - secretRef: password-encoder-secret
-  configOverrides:
-    server:
-      - confluent.cluster.link.enable=true
-      - password.encoder.secret=${file:/mnt/secrets/password-encoder-secret/password_encoder_secret:secret}
+  passwordEncoder:
+    secretRef: password-encoder-secret
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestClass


### PR DESCRIPTION
updated `passwordEncoder` in clusterlink example, and removed `confluent.cluster.link.enable` from the configOverrides since cluster linking is enabled [by default](https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/configs.html#using-cluster-linking-with-co-long) starting from Confluent Platform 7.0.0 