### PR TITLE
Update - external-access-static-host-based

### DIFF
--- a/networking/external-access-static-host-based/README.rst
+++ b/networking/external-access-static-host-based/README.rst
@@ -504,7 +504,7 @@ Shut down Confluent Platform and the data:
   
 ::
 
-  helm delete nginx-operator
+  helm delete ingress-nginx
 
 ::
 

--- a/networking/external-access-static-host-based/ingress-service-hostbased-example.yaml
+++ b/networking/external-access-static-host-based/ingress-service-hostbased-example.yaml
@@ -4,11 +4,11 @@ metadata:
   name: ingress-with-sni
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - kafka.mydomain.example
@@ -19,6 +19,16 @@ spec:
         - ksqldb.mydomain.example
         - connect.mydomain.example
   rules:
+    - host: kafka.mydomain.example
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-bootstrap
+                port: 
+                  number: 9092
     - host: b0.mydomain.example
       http:
         paths:
@@ -47,16 +57,6 @@ spec:
             backend:
               service:
                 name: kafka-2-internal
-                port: 
-                  number: 9092
-    - host: kafka.mydomain.example
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kafka-bootstrap
                 port: 
                   number: 9092
     - host: controlcenter.mydomain.example

--- a/networking/external-access-static-host-based/ingress-service-hostbased-example.yaml
+++ b/networking/external-access-static-host-based/ingress-service-hostbased-example.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-with-sni
@@ -19,45 +19,73 @@ spec:
         - ksqldb.mydomain.example
         - connect.mydomain.example
   rules:
-    - host: kafka.mydomain.example
-      http:
-        paths:
-          - backend:
-              serviceName: kafka-bootstrap
-              servicePort: 9092
     - host: b0.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: kafka-0-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service: 
+                name: kafka-0-internal
+                port:
+                  number: 9092
     - host: b1.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: kafka-1-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-1-internal
+                port: 
+                  number: 9092
     - host: b2.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: kafka-2-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-2-internal
+                port: 
+                  number: 9092
+    - host: kafka.mydomain.example
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-bootstrap
+                port: 
+                  number: 9092
     - host: controlcenter.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: controlcenter-0-internal
-              servicePort: 9021
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: controlcenter-0-internal
+                port: 
+                  number: 9021
     - host: ksqldb.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: ksqldb-bootstrap
-              servicePort: 8088
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ksqldb-bootstrap
+                port: 
+                  number: 8088
     - host: connect.mydomain.example
       http:
         paths:
-          - backend:
-              serviceName: connect-bootstrap
-              servicePort: 8083
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: connect-bootstrap
+                port: 
+                  number: 8083

--- a/networking/external-access-static-host-based/ingress-service-hostbased.yaml
+++ b/networking/external-access-static-host-based/ingress-service-hostbased.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-with-sni
@@ -19,45 +19,73 @@ spec:
         - ksqldb.$DOMAIN
         - connect.$DOMAIN
   rules:
-    - host: kafka.$DOMAIN
-      http:
-        paths:
-          - backend:
-              serviceName: kafka-bootstrap
-              servicePort: 9092
     - host: b0.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-0-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service: 
+                name: kafka-0-internal
+                port:
+                  number: 9092
     - host: b1.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-1-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-1-internal
+                port: 
+                  number: 9092
     - host: b2.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: kafka-2-internal
-              servicePort: 9092
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-2-internal
+                port: 
+                  number: 9092
+    - host: kafka.$DOMAIN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-bootstrap
+                port: 
+                  number: 9092
     - host: controlcenter.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: controlcenter-0-internal
-              servicePort: 9021
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: controlcenter-0-internal
+                port: 
+                  number: 9021
     - host: ksqldb.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: ksqldb-bootstrap
-              servicePort: 8088
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ksqldb-bootstrap
+                port: 
+                  number: 8088
     - host: connect.$DOMAIN
       http:
         paths:
-          - backend:
-              serviceName: connect-bootstrap
-              servicePort: 8083
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: connect-bootstrap
+                port: 
+                  number: 8083

--- a/networking/external-access-static-host-based/ingress-service-hostbased.yaml
+++ b/networking/external-access-static-host-based/ingress-service-hostbased.yaml
@@ -4,11 +4,11 @@ metadata:
   name: ingress-with-sni
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - kafka.$DOMAIN
@@ -19,6 +19,16 @@ spec:
         - ksqldb.$DOMAIN
         - connect.$DOMAIN
   rules:
+    - host: kafka.$DOMAIN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kafka-bootstrap
+                port: 
+                  number: 9092
     - host: b0.$DOMAIN
       http:
         paths:
@@ -47,16 +57,6 @@ spec:
             backend:
               service:
                 name: kafka-2-internal
-                port: 
-                  number: 9092
-    - host: kafka.$DOMAIN
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kafka-bootstrap
                 port: 
                   number: 9092
     - host: controlcenter.$DOMAIN

--- a/networking/external-access-static-host-based/topic.yaml
+++ b/networking/external-access-static-host-based/topic.yaml
@@ -4,7 +4,6 @@ metadata:
   name: elastic-0
   namespace: confluent 
 spec:
-  replicas: 1
   partitionCount: 1
   configs:
     cleanup.policy: "delete"


### PR DESCRIPTION
ingress-service-hostbased.yaml: networking.k8s.io/v1beta1 is deprecated in Kubernetes v1.22. Currently, networking.k8s.io/v1 is only supported for the new Kubernetes versions.

README.rst: The Helm release is called "ingress-nginx" instead of "nginx-operator"

topic.yaml: In this example, the brokers are configured with "min.insync.replicas = 2". I've observed that the option "replicas: 1" makes the topic to be unavailable so the producer gets an error when trying to write to topic "elastic-0". Removing that option the issue is solved.