### PR TITLE
memory usage panel is not accurate

### DIFF
--- a/monitoring/grafana-dashboard/confluent-platform.json
+++ b/monitoring/grafana-dashboard/confluent-platform.json
@@ -539,7 +539,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_memory_usage_bytes{pod=~\"$component_name-(\\\\d+)\"}) by (pod)",
+          "expr": "container_memory_usage_bytes{pod=~\"$component_name-(\\\\d+)\", container="$component_name"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
the memory usage panel is doing a sum accross pods with names kafka but its not giving accurate numbers. I have added the container name and its accurate now