### PR TITLE
Fix the integration between ldap and mds

### DIFF
--- a/assets/openldap/values.yaml
+++ b/assets/openldap/values.yaml
@@ -22,6 +22,7 @@ ldifs:
     dn: cn=kafka,{{ LDAP_BASE_DN }}
     userPassword: kafka-secret
     description: kafka user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: kafka
@@ -29,6 +30,7 @@ ldifs:
     dn: cn=erp,{{ LDAP_BASE_DN }}
     userPassword: erp-secret
     description: erp user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: erp
@@ -36,6 +38,7 @@ ldifs:
     dn: cn=sr,{{ LDAP_BASE_DN }}
     userPassword: sr-secret
     description: schema registry user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: sr
@@ -43,6 +46,7 @@ ldifs:
     dn: cn=c3,{{ LDAP_BASE_DN }}
     userPassword: c3-secret
     description: control center user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: c3
@@ -50,6 +54,7 @@ ldifs:
     dn: cn=ksql,{{ LDAP_BASE_DN }}
     userPassword: ksql-secret
     description: ksql user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: ksql
@@ -57,6 +62,7 @@ ldifs:
     dn: cn=connect,{{ LDAP_BASE_DN }}
     userPassword: connect-secret
     description: connect user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: connect
@@ -64,6 +70,7 @@ ldifs:
     dn: cn=replicator,{{ LDAP_BASE_DN }}
     userPassword: replicator-secret
     description: replicator user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: replicator
@@ -71,6 +78,7 @@ ldifs:
     dn: cn=krp,{{ LDAP_BASE_DN }}
     userPassword: krp-secret
     description: krp user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: krp
@@ -78,6 +86,7 @@ ldifs:
     dn: cn=testadmin,{{ LDAP_BASE_DN }}
     userPassword: testadmin
     description: testadmin user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: testadmin
@@ -103,6 +112,7 @@ ldifs:
     gidNumber: 5000
   12_alice.ldif:  |-
     dn: cn=alice,ou=users,{{ LDAP_BASE_DN }}
+    objectClass: top
     objectClass: inetOrgPerson
     objectClass: posixAccount
     objectClass: shadowAccount
@@ -119,6 +129,7 @@ ldifs:
     homeDirectory: /home/alice
   13_james.ldif:  |-
     dn: cn=james,ou=users,{{ LDAP_BASE_DN }}
+    objectClass: top
     objectClass: inetOrgPerson
     objectClass: posixAccount
     objectClass: shadowAccount
@@ -147,6 +158,7 @@ ldifs:
     dn: cn=devuser,{{ LDAP_BASE_DN }}
     userPassword: dev-password
     description: Developer user
+    objectClass: top
     objectClass: simpleSecurityObject
     objectClass: organizationalRole
     cn: devuser

--- a/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
+++ b/security/production-secure-deploy/confluent-platform-production-autogeneratedcerts.yaml
@@ -76,16 +76,17 @@ spec:
               secretRef: credential
           configurations:
             groupNameAttribute: cn
-            groupObjectClass: group
-            groupMemberAttribute: member
-            groupMemberAttributePattern: CN=(.*),DC=test,DC=com
+            groupObjectClass: posixGroup
+            groupMemberAttribute: memberUid
+            groupMemberAttributePattern: cn=(.*),ou=users,dc=test,dc=com
             groupSearchBase: dc=test,dc=com
-            groupSearchScope: 1
+            groupSearchScope: 2
             userNameAttribute: cn
             userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
-            userObjectClass: organizationalRole
+            userObjectClass: top
             userSearchBase: dc=test,dc=com
-            userSearchScope: 1
+            userSearchFilter: (|(objectClass=organizationalRole)(objectClass=posixAccount))
+            userSearchScope: 2
   dependencies:
     kafkaRest:
       authentication:

--- a/security/production-secure-deploy/confluent-platform-production-mtls.yaml
+++ b/security/production-secure-deploy/confluent-platform-production-mtls.yaml
@@ -78,16 +78,17 @@ spec:
               secretRef: credential
           configurations:
             groupNameAttribute: cn
-            groupObjectClass: group
-            groupMemberAttribute: member
-            groupMemberAttributePattern: CN=(.*),DC=test,DC=com
+            groupObjectClass: posixGroup
+            groupMemberAttribute: memberUid
+            groupMemberAttributePattern: cn=(.*),ou=users,dc=test,dc=com
             groupSearchBase: dc=test,dc=com
-            groupSearchScope: 1
+            groupSearchScope: 2
             userNameAttribute: cn
             userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
-            userObjectClass: organizationalRole
+            userObjectClass: top
             userSearchBase: dc=test,dc=com
-            userSearchScope: 1
+            userSearchFilter: (|(objectClass=organizationalRole)(objectClass=posixAccount))
+            userSearchScope: 2
   dependencies:
     kafkaRest:
       authentication:

--- a/security/production-secure-deploy/confluent-platform-production.yaml
+++ b/security/production-secure-deploy/confluent-platform-production.yaml
@@ -76,16 +76,17 @@ spec:
               secretRef: credential
           configurations:
             groupNameAttribute: cn
-            groupObjectClass: group
-            groupMemberAttribute: member
-            groupMemberAttributePattern: CN=(.*),DC=test,DC=com
+            groupObjectClass: posixGroup
+            groupMemberAttribute: memberUid
+            groupMemberAttributePattern: cn=(.*),ou=users,dc=test,dc=com
             groupSearchBase: dc=test,dc=com
-            groupSearchScope: 1
+            groupSearchScope: 2
             userNameAttribute: cn
             userMemberOfAttributePattern: CN=(.*),DC=test,DC=com
-            userObjectClass: organizationalRole
+            userObjectClass: top
             userSearchBase: dc=test,dc=com
-            userSearchScope: 1
+            userSearchFilter: (|(objectClass=organizationalRole)(objectClass=posixAccount))
+            userSearchScope: 2
   dependencies:
     kafkaRest:
       authentication:

--- a/security/production-secure-deploy/controlcenter-testadmin-rolebindings.yaml
+++ b/security/production-secure-deploy/controlcenter-testadmin-rolebindings.yaml
@@ -72,3 +72,14 @@ spec:
   #kafkaRestClassRef:
   # name: default
 ---
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: mds-admin
+  namespace: confluent
+spec:
+  principal:
+    type: user
+    name: mds
+  role: SystemAdmin
+---


### PR DESCRIPTION
Fix the integration between ldap and mds to allow the selection of roles and users in C3.

Add a common 'top' objectClass to each account to be able to select them.
Modify the mds ldap configuation to match the ldap existing tree.

Now it allows also to login with 'alice' and 'james' users and grant permissions to specific existing users and to 'readonlyusers'  and 'c3users' groups