### PR TITLE
Update confluent-platform-secure.yaml to have correct config properties

### DIFF
--- a/security/secure-authn-encrypt-deploy/confluent-platform-secure.yaml
+++ b/security/secure-authn-encrypt-deploy/confluent-platform-secure.yaml
@@ -43,13 +43,7 @@ spec:
         enabled: true
   metricReporter:
     enabled: true
-    bootstrapEndpoint: kafka:9071
-    tls:
-      enabled: true
-    authentication:
-      type: plain
-      jaasConfig:
-        secretRef: credential
+    bootstrapEndpoint: kafka:9092
   dependencies:
     zookeeper:
       endpoint: zookeeper.confluent.svc.cluster.local:2182
@@ -111,7 +105,7 @@ metadata:
   name: schemaregistry
   namespace: confluent
 spec:
-  replicas: 3
+  replicas: 1
   image:
     application: confluentinc/cp-schema-registry:7.4.0
     init: confluentinc/confluent-init-container:2.6.0
@@ -185,7 +179,7 @@ spec:
         enabled: true
     ksqldb:
     - name: ksql-dev
-      url: https://ksqldb-tls.confluent.svc.cluster.local:8088
+      url: https://ksqldb.confluent.svc.cluster.local:8088
       tls:
         enabled: true
     connect:

--- a/security/secure-authn-encrypt-deploy/confluent-platform-secure.yaml
+++ b/security/secure-authn-encrypt-deploy/confluent-platform-secure.yaml
@@ -43,7 +43,13 @@ spec:
         enabled: true
   metricReporter:
     enabled: true
-    bootstrapEndpoint: kafka:9092
+    bootstrapEndpoint: kafka:9071
+    tls:
+      enabled: true
+    authentication:
+      type: plain
+      jaasConfig:
+        secretRef: credential
   dependencies:
     zookeeper:
       endpoint: zookeeper.confluent.svc.cluster.local:2182
@@ -105,7 +111,7 @@ metadata:
   name: schemaregistry
   namespace: confluent
 spec:
-  replicas: 1
+  replicas: 3
   image:
     application: confluentinc/cp-schema-registry:7.4.0
     init: confluentinc/confluent-init-container:2.6.0
@@ -179,7 +185,7 @@ spec:
         enabled: true
     ksqldb:
     - name: ksql-dev
-      url: https://ksqldb.confluent.svc.cluster.local:8088
+      url: https://ksqldb-tls.confluent.svc.cluster.local:8088
       tls:
         enabled: true
     connect:


### PR DESCRIPTION
The current `confluent-platform-secure.yaml` have some configs missing when deployed to Kubernetes cluster, this PR adds the missing config and also updates some properties:

1. when tls is set to `true`, we also need to put `tls` and `authentication` properties under `metricReporter`, otherwise Kafka won't be provisioned
2. based on my understanding, the schema registry should match the replicas that Kafka and broker otherwise `NotEnoughReplicasException` will be thrown in schema registry pods
3. the correct URL of ksqldb should be `ksqldb-tls`, otherwise control center will complain the ksqldb host can not be found