### PR TITLE
adding vertica to ccloud example via jdbc [skip secret scan] 

### DIFF
--- a/hybrid/ccloud-JDBC-vertica/README.md
+++ b/hybrid/ccloud-JDBC-vertica/README.md
@@ -1,0 +1,247 @@
+# Kafka Connect to Confluent Cloud
+
+In this example, you'll set up the following:  
+*  Deploy a self managed MySql server for the connector to utilize  
+*  Self-managed Kafka Connect cluster connected to Confluent Cloud
+*  Install and manage the JDBC source connector plugin through the declarative `Connector` CRD  
+*  Install and manage the JDBC source connector plugin through the Connect REST endpoint  
+
+
+## Set up Pre-requisites
+
+Set the tutorial directory for this tutorial under the directory you downloaded the tutorial files:
+
+```
+export TUTORIAL_HOME=<Tutorial directory>/hybrid/ccloud-JDBC-mysql
+```
+
+Create namespace
+
+```
+kubectl create ns confluent
+```
+### Create Mysql server 
+
+We are following the [kubernetes](https://kubernetes.io/docs/tasks/run-application/run-single-instance-stateful-application/)
+
+
+```
+kubectl config set-context --current --namespace=confluent
+kubectl apply -f https://k8s.io/examples/application/mysql/mysql-pv.yaml
+kubectl apply -f https://k8s.io/examples/application/mysql/mysql-deployment.yaml
+kubectl get pods -l app=mysql
+kubectl run -it --rm --image=mysql:5.6 --restart=Never mysql-client -- mysql -h mysql -ppassword
+```
+
+Inside the shell you will create a database, table and entries:  
+
+```
+CREATE DATABASE IF NOT EXISTS connect_test;
+USE connect_test;
+
+DROP TABLE IF EXISTS test;
+
+
+CREATE TABLE IF NOT EXISTS test (
+  id serial NOT NULL PRIMARY KEY,
+  name varchar(100),
+  email varchar(200),
+  department varchar(200),
+  modified timestamp default CURRENT_TIMESTAMP NOT NULL,
+  INDEX `modified_index` (`modified`)
+);
+
+INSERT INTO test (name, email, department) VALUES ('alice', 'alice@abc.com', 'engineering');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('alice', 'alice@abc.com', 'engineering');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+INSERT INTO test (name, email, department) VALUES ('bob', 'bob@abc.com', 'sales');
+```
+
+
+## Deploy Confluent for Kubernetes
+
+This workflow scenario assumes you are using the namespace `confluent`.
+
+Set up the Helm Chart:
+
+```
+helm repo add confluentinc https://packages.confluent.io/helm
+```
+
+Install Confluent For Kubernetes using Helm:
+
+```
+helm upgrade --install operator confluentinc/confluent-for-kubernetes -n confluent
+```
+ 
+Check that the Confluent For Kubernetes pod comes up and is running:
+
+```
+kubectl get pods -n confluent
+```
+
+## Create Kubernetes Secrets for Confluent Cloud API Key and Confluent Cloud Schema Registry API Key
+
+Add user name and key for the hosted Confluent Platform (Cloud and Schema)
+
+```
+kubectl -n confluent create secret generic ccloud-credentials --from-file=plain.txt=$TUTORIAL_HOME/ccloud-credentials.txt  
+
+kubectl -n confluent create secret generic ccloud-sr-credentials --from-file=basic.txt=$TUTORIAL_HOME/ccloud-sr-credentials.txt
+```
+
+## Create Kubernetes Secret for the JDBC connector to pull connection URL and password for the mysql server
+
+```
+ kubectl -n confluent create secret generic mysql-credential \
+  --from-file=sqlcreds.txt=$TUTORIAL_HOME/sqlcreds.txt
+```
+## Deploy self-managed Kafka Connect connecting to Confluent Cloud
+
+```
+kubectl -n confluent apply -f $TUTORIAL_HOME/kafka-connect.yaml
+```
+## Shell to the Connect Container  
+
+```
+kubectl exec connect-0 -it -n confluent -- bash
+```
+
+Create consumer properties file:  
+```
+cat << EOF > /opt/confluentinc/etc/connect/consumer.properties
+bootstrap.servers=CCLOUD:9092
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule   required username="ccloud-key"   password="ccloud-secret";
+ssl.endpoint.identification.algorithm=https
+sasl.mechanism=PLAIN
+EOF
+```
+
+### Create topic to load data from table into (CRD connector)
+```
+kafka-topics --command-config /opt/confluentinc/etc/connect/consumer.properties \
+--bootstrap-server CCLOUD:9092  \
+--create \
+--partitions 3 \
+--replication-factor 3 \
+--topic quickstart-jdbc-CRD-test
+```
+
+### Create topic to load data from table into (REST API endpoint connector)
+
+```
+kafka-topics --command-config /opt/confluentinc/etc/connect/consumer.properties \
+--bootstrap-server CCLOUD:9092  \
+--create \
+--partitions 3 \
+--replication-factor 3 \
+--topic quickstart-jdbc-test
+```
+
+
+
+## Create Connector
+
+
+### Example for the CRD connector  
+
+Outside the Connect pod shell you can issue the command:  
+```
+ kubectl -n confluent apply -f $TUTORIAL_HOME/connector.yaml 
+```
+
+### Example for the REST API endpoint connector  
+Create jdbc source connector 
+```
+curl -X POST \
+-H "Content-Type: application/json" \
+--data '{ "name": "quickstart-jdbc-source", "config": { "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector", "tasks.max": 1, "connection.url": "jdbc:mysql://mysql:3306/connect_test?user=root&password=password", "mode": "incrementing", "incrementing.column.name": "id", "timestamp.column.name": "modified", "topic.prefix": "quickstart-jdbc-", "poll.interval.ms": 1000 } }' \
+http://localhost:8083/connectors/
+```
+
+## Validation
+
+### Check Connector  
+Check if connector is running   
+#### CRD connector  endpoint 
+```
+curl -X GET http://localhost:8083/connectors/mysqlviacrd/status
+```
+
+#### REST API connector endpoint    
+```
+curl -X GET http://localhost:8083/connectors/quickstart-jdbc-source/status
+```
+### Consume from Cloud topic
+
+Create `log4j` file:  
+
+```
+cat << EOF > /tmp/log4j.properties
+log4j.rootLogger=WARN, stderr
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stderr.Target=System.err 
+EOF
+```
+
+Export path:  
+```
+export SCHEMA_REGISTRY_OPTS="-Dlog4j.configuration=file:/tmp/log4j.properties"
+```  
+
+#### Consume from the topic that is used by the CRD created connector:
+
+```
+kafka-avro-console-consumer \
+--bootstrap-server CCLOUD:9092 \
+--topic quickstart-jdbc-CRD-test \
+--consumer.config /opt/confluentinc/etc/connect/consumer.properties \
+--property schema.registry.url=SR_URL \
+--property schema.registry.basic.auth.user.info=SR_USER:SR_SECRET \
+--property basic.auth.credentials.source=USER_INFO \
+--from-beginning
+```
+
+#### Consume from the topic that is used by the REST API created connector:
+
+```
+kafka-avro-console-consumer \
+--bootstrap-server CCLOUD:9092 \
+--topic quickstart-jdbc-test \
+--consumer.config /opt/confluentinc/etc/connect/consumer.properties \
+--property schema.registry.url=SR_URL \
+--property schema.registry.basic.auth.user.info=SR_USER:SR_SECRET \
+--property basic.auth.credentials.source=USER_INFO \
+--from-beginning
+```
+
+You should see the table entries. 
+
+## Tear down
+```
+kubectl delete -f $TUTORIAL_HOME/kafka-connect.yaml
+kubectl delete deployment,svc mysql
+kubectl delete pvc mysql-pv-claim
+kubectl delete pv mysql-pv-volume
+kubectl delete pod mysql-client  
+```
+

--- a/hybrid/ccloud-JDBC-vertica/ccloud-credentials.txt
+++ b/hybrid/ccloud-JDBC-vertica/ccloud-credentials.txt
@@ -1,0 +1,2 @@
+username=
+password=

--- a/hybrid/ccloud-JDBC-vertica/ccloud-credentials.txt
+++ b/hybrid/ccloud-JDBC-vertica/ccloud-credentials.txt
@@ -1,2 +1,2 @@
-username=
-password=
+username=cloud-key
+password=cloud-secret

--- a/hybrid/ccloud-JDBC-vertica/ccloud-sr-credentials.txt
+++ b/hybrid/ccloud-JDBC-vertica/ccloud-sr-credentials.txt
@@ -1,0 +1,2 @@
+username=
+password=

--- a/hybrid/ccloud-JDBC-vertica/ccloud-sr-credentials.txt
+++ b/hybrid/ccloud-JDBC-vertica/ccloud-sr-credentials.txt
@@ -1,2 +1,2 @@
-username=
-password=
+username=sr-key
+password=sr-secret

--- a/hybrid/ccloud-JDBC-vertica/connector.yaml
+++ b/hybrid/ccloud-JDBC-vertica/connector.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: Connector
+metadata:
+  name: mysqlviacrd
+  namespace: confluent
+spec:
+  class: "io.confluent.connect.jdbc.JdbcSourceConnector"
+  taskMax: 1
+  connectClusterRef:
+    name: connect
+  configs:
+    connection.url: ${file:/mnt/secrets/mysql-credential/sqlcreds.txt:connection}
+    mode: "incrementing"
+    incrementing.column.name: "id"
+    timestamp.column.name: "modified"
+    topic.prefix: "quickstart-jdbc-CRD-"
+    poll.interval.ms: "1000"

--- a/hybrid/ccloud-JDBC-vertica/connector.yaml
+++ b/hybrid/ccloud-JDBC-vertica/connector.yaml
@@ -2,17 +2,18 @@
 apiVersion: platform.confluent.io/v1beta1
 kind: Connector
 metadata:
-  name: mysqlviacrd
+  name: verticacrd
   namespace: confluent
 spec:
   class: "io.confluent.connect.jdbc.JdbcSourceConnector"
   taskMax: 1
   connectClusterRef:
-    name: connect
+    name: connectverticademo
   configs:
-    connection.url: ${file:/mnt/secrets/mysql-credential/sqlcreds.txt:connection}
-    mode: "incrementing"
-    incrementing.column.name: "id"
-    timestamp.column.name: "modified"
-    topic.prefix: "quickstart-jdbc-CRD-"
-    poll.interval.ms: "1000"
+    connection.url: "jdbc:vertica://vertica:5433/docker"
+    connection.user: "readonlymoshe"
+    connection.password: "password"
+    topic.prefix: "verticacrd_" # topic name tp create:  verticacrd_test  : prefix + table name
+    poll.interval.ms : "5000"
+    mode: "bulk"
+    table.whitelist: "test"

--- a/hybrid/ccloud-JDBC-vertica/kafka-connect.yaml
+++ b/hybrid/ccloud-JDBC-vertica/kafka-connect.yaml
@@ -2,7 +2,7 @@
 apiVersion: platform.confluent.io/v1beta1
 kind: Connect
 metadata:
-  name: connect
+  name: connectverticademo
 spec:
   keyConverterType: io.confluent.connect.avro.AvroConverter
   valueConverterType: io.confluent.connect.avro.AvroConverter
@@ -17,8 +17,8 @@ spec:
         locationType: url
         url:
           - name: kafka-connect-jdbc # the url is used here as we needed to build our own connector lib to include the mysql jdbc jar
-            archivePath: https://raw.githubusercontent.com/confluentinc/confluent-kubernetes-examples/master/hybrid/ccloud-JDBC-mysql/confluentinc-kafka-connect-jdbc-10.2.5.zip
-            checksum: 9d033fabac89ec0b35a97246f7ca3a36800bcb402ccfbd76adebd4c4c9ca6e7d6a044a9162383a18f99400893581b55a87b9fe89e35276507e9a3fb6cff3fda0
+            archivePath: https://raw.githubusercontent.com/MosheBlumbergX/confluent-kubernetes-examples/vertica/hybrid/ccloud-JDBC-vertica/confluentinc-kafka-connect-jdbc-10.2.5.zip
+            checksum: 63f7b70ff5db57125c0666f1a2a9e3a47bb69bace9485a4f2bd7dcb319c05c26df9eea74d0a690e8c1325eac687b3abd4838a875597b71ea32198c8270abc88b
   dependencies:
     kafka:
       bootstrapEndpoint: <cloudKafka_url>:9092
@@ -35,5 +35,3 @@ spec:
         type: basic
         basic:
           secretRef: ccloud-sr-credentials
-  mountedSecrets:
-  - secretRef: mysql-credential

--- a/hybrid/ccloud-JDBC-vertica/kafka-connect.yaml
+++ b/hybrid/ccloud-JDBC-vertica/kafka-connect.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: Connect
+metadata:
+  name: connect
+spec:
+  keyConverterType: io.confluent.connect.avro.AvroConverter
+  valueConverterType: io.confluent.connect.avro.AvroConverter
+  replicas: 1
+  image:
+    application: confluentinc/cp-server-connect:7.5.0
+    init: confluentinc/confluent-init-container:2.7.0
+  build:
+    type: onDemand
+    onDemand:
+      plugins:
+        locationType: url
+        url:
+          - name: kafka-connect-jdbc # the url is used here as we needed to build our own connector lib to include the mysql jdbc jar
+            archivePath: https://raw.githubusercontent.com/confluentinc/confluent-kubernetes-examples/master/hybrid/ccloud-JDBC-mysql/confluentinc-kafka-connect-jdbc-10.2.5.zip
+            checksum: 9d033fabac89ec0b35a97246f7ca3a36800bcb402ccfbd76adebd4c4c9ca6e7d6a044a9162383a18f99400893581b55a87b9fe89e35276507e9a3fb6cff3fda0
+  dependencies:
+    kafka:
+      bootstrapEndpoint: <cloudKafka_url>:9092
+      authentication:
+        type: plain
+        jaasConfig:
+          secretRef: ccloud-credentials
+      tls:
+        enabled: true
+        ignoreTrustStoreConfig: true 
+    schemaRegistry:
+      url: https://<cloudSR_url>
+      authentication:
+        type: basic
+        basic:
+          secretRef: ccloud-sr-credentials
+  mountedSecrets:
+  - secretRef: mysql-credential

--- a/hybrid/ccloud-JDBC-vertica/sqlcreds.txt
+++ b/hybrid/ccloud-JDBC-vertica/sqlcreds.txt
@@ -1,0 +1,5 @@
+connection=jdbc:mysql://mysql:3306/connect_test?user=root&password=password
+
+
+
+

--- a/hybrid/ccloud-JDBC-vertica/sqlcreds.txt
+++ b/hybrid/ccloud-JDBC-vertica/sqlcreds.txt
@@ -1,5 +1,0 @@
-connection=jdbc:mysql://mysql:3306/connect_test?user=root&password=password
-
-
-
-

--- a/hybrid/ccloud-JDBC-vertica/vertica-deployment.yaml
+++ b/hybrid/ccloud-JDBC-vertica/vertica-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service_vertica: vertica
+  name: vertica
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service_vertica: vertica
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        service_vertica: vertica
+    spec:
+      containers:
+        - image: cjonesy/docker-vertica
+          name: vertica
+          ports:
+            - containerPort: 5433
+          resources: {}
+      hostname: vertica
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service_vertica: vertica
+  name: vertica
+spec:
+  ports:
+    - name: "5433"
+      port: 5433
+      targetPort: 5433
+  selector:
+    service_vertica: vertica
+


### PR DESCRIPTION
In this example, you'll set up the following:  
*  Deploy a self managed Vertica server for the connector to utilize  
*  Self-managed Kafka Connect cluster connected to Confluent Cloud
*  Install and manage the JDBC source connector plugin through the declarative `Connector` CRD using bulk mode 
*  Install and manage the JDBC source connector plugin through the Connect REST endpoint  using timestamp+incrementing mode

