### PR TITLE
Updating Basic Auth example for all CP components 

### DIFF
--- a/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicConnect.txt
+++ b/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicConnect.txt
@@ -1,1 +1,0 @@
-thisismyusername: thisismypass

--- a/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicsecretSRC3.txt
+++ b/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicsecretSRC3.txt
@@ -1,2 +1,0 @@
-username=thisismyusername
-password=thisismypass

--- a/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicwithroleSR.txt
+++ b/security/plaintext-basic-auth-ConnectAndSchemaRegistry/basicwithroleSR.txt
@@ -1,1 +1,0 @@
-thisismyusername: thisismypass,admin

--- a/security/plaintext-basic-auth/client-side/basicsecretConnect.txt
+++ b/security/plaintext-basic-auth/client-side/basicsecretConnect.txt
@@ -1,0 +1,2 @@
+username=connectUser
+password=thisismypass

--- a/security/plaintext-basic-auth/client-side/basicsecretSR.txt
+++ b/security/plaintext-basic-auth/client-side/basicsecretSR.txt
@@ -1,0 +1,2 @@
+username=srUser
+password=thisismypass

--- a/security/plaintext-basic-auth/client-side/basicsecretksql.txt
+++ b/security/plaintext-basic-auth/client-side/basicsecretksql.txt
@@ -1,0 +1,2 @@
+username=ksqlUser
+password=thisismypass

--- a/security/plaintext-basic-auth/confluent-platform.yaml
+++ b/security/plaintext-basic-auth/confluent-platform.yaml
@@ -45,18 +45,6 @@ spec:
       bootstrapEndpoint: kafka:9071
 ---
 apiVersion: platform.confluent.io/v1beta1
-kind: KsqlDB
-metadata:
-  name: ksqldb
-  namespace: confluent
-spec:
-  replicas: 1
-  image:
-    application: confluentinc/cp-ksqldb-server:7.5.0
-    init: confluentinc/confluent-init-container:2.7.0
-  dataVolumeCapacity: 10Gi
----
-apiVersion: platform.confluent.io/v1beta1
 kind: SchemaRegistry
 metadata:
   name: schemaregistry
@@ -71,7 +59,42 @@ spec:
     basic:
       secretRef: basicwithrolesr
       roles:
-      - admin 
+        - admin
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KsqlDB
+metadata:
+  name: ksqldb
+  namespace: confluent
+spec:
+  replicas: 1
+  authentication:
+    type: basic
+    basic:
+      secretRef: basicwithroleksql
+      roles:
+        - admin
+  image:
+    application: confluentinc/cp-ksqldb-server:7.5.0
+    init: confluentinc/confluent-init-container:2.7.0
+  dataVolumeCapacity: 10Gi
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestProxy
+metadata:
+  name: kafkarestproxy
+  namespace: confluent
+spec:
+  replicas: 1
+  authentication:
+    type: basic
+    basic:
+      secretRef: basicwithrolerp
+      roles:
+        - admin
+  image:
+    application: confluentinc/cp-kafka-rest:7.5.0
+    init: confluentinc/confluent-init-container:2.7.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: ControlCenter
@@ -80,17 +103,37 @@ metadata:
   namespace: confluent
 spec:
   replicas: 1
+  authentication:
+    type: basic
+    basic:
+      secretRef: basicwithrolec3
+      roles:
+        - Administrators
+        - Restricted
+      restrictedRoles:
+        - Restricted
   image:
     application: confluentinc/cp-enterprise-control-center:7.5.0
     init: confluentinc/confluent-init-container:2.7.0
   dataVolumeCapacity: 10Gi
   dependencies:
+    connect:
+      - name: connect
+        url: http://connect.confluent.svc.cluster.local:8083
+        authentication:
+          type: basic
+          basic:
+            secretRef: basicsecretconnectclient
     ksqldb:
     - name: ksqldb
       url: http://ksqldb.confluent.svc.cluster.local:8088
+      authentication:
+        type: basic
+        basic:
+          secretRef: basicsecretksqlclient
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081
       authentication:
         type: basic
         basic:
-          secretRef: basicsecretsrccc
+          secretRef: basicsecretsrclient

--- a/security/plaintext-basic-auth/producer-consumer-app-data.yaml
+++ b/security/plaintext-basic-auth/producer-consumer-app-data.yaml
@@ -42,7 +42,7 @@ spec:
             --property schema.registry.url=http://schemaregistry.confluent.svc.cluster.local:8081 \
             --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}' \
             --property basic.auth.credentials.source=USER_INFO \
-            --property schema.registry.basic.auth.user.info=thisismyusername:thisismypass \
+            --property schema.registry.basic.auth.user.info=srUser:thisismypass \
             --topic producer-example-0 
     volumeMounts:
         - name: kafka-properties
@@ -77,7 +77,7 @@ spec:
         --consumer.config /mnt/kafka.properties \
         --property schema.registry.url=http://schemaregistry.confluent.svc.cluster.local:8081 \
         --property basic.auth.credentials.source=USER_INFO \
-        --property schema.registry.basic.auth.user.info=thisismyusername:thisismypass \
+        --property schema.registry.basic.auth.user.info=srUser:thisismypass \
         --topic producer-example-0 \
         --from-beginning \
         --timeout-ms 5000

--- a/security/plaintext-basic-auth/server-side/basicConnect.txt
+++ b/security/plaintext-basic-auth/server-side/basicConnect.txt
@@ -1,0 +1,2 @@
+connectUser: thisismypass
+

--- a/security/plaintext-basic-auth/server-side/basicwithroleC3.txt
+++ b/security/plaintext-basic-auth/server-side/basicwithroleC3.txt
@@ -1,0 +1,3 @@
+c3admin: password1,Administrators
+c3restricted: password2,Restricted
+

--- a/security/plaintext-basic-auth/server-side/basicwithroleKSQL.txt
+++ b/security/plaintext-basic-auth/server-side/basicwithroleKSQL.txt
@@ -1,0 +1,1 @@
+ksqlUser: thisismypass,admin

--- a/security/plaintext-basic-auth/server-side/basicwithroleRP.txt
+++ b/security/plaintext-basic-auth/server-side/basicwithroleRP.txt
@@ -1,0 +1,1 @@
+restproxyUser: thisismypass,admin

--- a/security/plaintext-basic-auth/server-side/basicwithroleSR.txt
+++ b/security/plaintext-basic-auth/server-side/basicwithroleSR.txt
@@ -1,0 +1,1 @@
+srUser: thisismypass,admin


### PR DESCRIPTION
The [current example](https://github.com/confluentinc/confluent-kubernetes-examples/tree/master/security/plaintext-basic-auth-ConnectAndSchemaRegistry) for basic authN covers connect and schema registry components. However, there are some other components that also support basic authN, therefore updated the basic auth example for all the CP components. 

Also, starting with CFK 2.4.1, Control Center supports connecting to the Connect and ksqlDB cluster using basic authentication: 

- [Release notes from CFK 2.4.1 ](https://docs.confluent.io/operator/2.4/release-notes.html#co-long-2-4-1-release-notes)