### PR TITLE
Revert "memory usage panel is not accurate"

### DIFF
--- a/monitoring/grafana-dashboard/confluent-platform.json
+++ b/monitoring/grafana-dashboard/confluent-platform.json
@@ -539,7 +539,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "container_memory_usage_bytes{pod=~\"$component_name-(\\\\d+)\", container="$component_name"}",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"$component_name-(\\\\d+)\"}) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
Reverts confluentinc/confluent-kubernetes-examples#194


The json in not valid 


```
Invalid JSON!

Error: Parse error on line 542:
...,          "expr": "container_memory_us
----------------------^
Expecting 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', got 'undefined'
```