### PR TITLE
Updating zookeeper endpoint format

### DIFF
--- a/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-central.yaml
+++ b/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-central.yaml
@@ -25,7 +25,7 @@ spec:
         jaasConfig:
           secretRef: credential
         type: digest
-      endpoint: zookeeper.central.svc.cluster.local:2182/mrc,zookeeper.east.svc.cluster.local:2182/mrc,zookeeper.west.svc.cluster.local:2182/mrc
+      endpoint: zookeeper.central.svc.cluster.local:2182,zookeeper.east.svc.cluster.local:2182,zookeeper.west.svc.cluster.local:2182/mrc
       tls:
         enabled: true
   image:

--- a/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-east.yaml
+++ b/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-east.yaml
@@ -27,7 +27,7 @@ spec:
         jaasConfig:
           secretRef: credential
         type: digest
-      endpoint: zookeeper.central.svc.cluster.local:2182/mrc,zookeeper.east.svc.cluster.local:2182/mrc,zookeeper.west.svc.cluster.local:2182/mrc
+      endpoint: zookeeper.central.svc.cluster.local:2182,zookeeper.east.svc.cluster.local:2182,zookeeper.west.svc.cluster.local:2182/mrc
       tls:
         enabled: true
   image:

--- a/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-west.yaml
+++ b/hybrid/multi-region-clusters/internal-listeners/confluent-platform/kafka/kafka-west.yaml
@@ -27,7 +27,7 @@ spec:
         jaasConfig:
           secretRef: credential
         type: digest
-      endpoint: zookeeper.central.svc.cluster.local:2182/mrc,zookeeper.east.svc.cluster.local:2182/mrc,zookeeper.west.svc.cluster.local:2182/mrc
+      endpoint: zookeeper.central.svc.cluster.local:2182,zookeeper.east.svc.cluster.local:2182,zookeeper.west.svc.cluster.local:2182/mrc
       tls:
         enabled: true
   image:


### PR DESCRIPTION
With multiple zookeepers, the chroot needs to be specified once at the end of the string in the endpoint. 
      
`endpoint: 
    zookeeper.central.svc.cluster.local:2182,zookeeper.east.svc.cluster.local:2182,zookeeper.west.svc.cluster.local:2182/mrc
`

