### PR TITLE
Extra white space in credential secret.

### DIFF
--- a/security/control-center-sso/README.md
+++ b/security/control-center-sso/README.md
@@ -116,7 +116,7 @@ kubectl create secret generic credential \
 --from-file=plain-users.json=$TUTORIAL_HOME/creds-kafka-sasl-users.json \
 --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \
 --from-file=ldap.txt=$TUTORIAL_HOME/ldap.txt \
---from-file=oidcClientSecret.txt=$TUTORIAL_HOME/oidcClientSecret.txt \ 
+--from-file=oidcClientSecret.txt=$TUTORIAL_HOME/oidcClientSecret.txt \
 -n confluent
 ```
 


### PR DESCRIPTION
Extra white space in credential secret, prevents secret from getting created correctly.