### PR TITLE
Update README.md to fix base directory to basic.

### DIFF
--- a/hybrid/schemalink/basic/README.md
+++ b/hybrid/schemalink/basic/README.md
@@ -11,7 +11,7 @@
 - Set the tutorial directory for this tutorial under the directory you downloaded
   the tutorial files:
 ```
-export TUTORIAL_HOME=<Tutorial directory>/hybrid/schemalink/mtls
+export TUTORIAL_HOME=<Tutorial directory>/hybrid/schemalink/basic
 ```
 
 - Deploy Confluent for Kubernetes (CFK) in cluster mode, so that the one CFK instance can manage Confluent deployments in multiple namespaces. Here, CFk is deployed to the `default` namespace.

--- a/security/control-center-sso/README.md
+++ b/security/control-center-sso/README.md
@@ -116,7 +116,7 @@ kubectl create secret generic credential \
 --from-file=plain-users.json=$TUTORIAL_HOME/creds-kafka-sasl-users.json \
 --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \
 --from-file=ldap.txt=$TUTORIAL_HOME/ldap.txt \
---from-file=oidcClientSecret.txt=$TUTORIAL_HOME/oidcClientSecret.txt \ 
+--from-file=oidcClientSecret.txt=$TUTORIAL_HOME/oidcClientSecret.txt \
 -n confluent
 ```
 


### PR DESCRIPTION
Minor update to update README.md to fix the base directory to `basic` instead of the `mtls` example.