### PR TITLE
replicator extension version updated to match image version

### DIFF
--- a/hybrid/replicator-cloud2cloud/components-destination.yaml
+++ b/hybrid/replicator-cloud2cloud/components-destination.yaml
@@ -12,7 +12,7 @@ spec:
   podTemplate:
     envVars:
       - name: CLASSPATH
-        value: /usr/share/java/kafka-connect-replicator/replicator-rest-extension-7.4.0.jar
+        value: /usr/share/java/kafka-connect-replicator/replicator-rest-extension-7.6.0.jar
   configOverrides:
     server:
       # To activate the monitoring extension, configure this property


### PR DESCRIPTION
replicator extension jar version changed to v7.6.0 to match image version. Without this connect worker fails to starts with the following error:
```replicator [ERROR] 2024-04-18 03:30:33,334 [main] org.apache.kafka.connect.cli.AbstractConnectCli startConnect - Failed to start Connect
replicator org.apache.kafka.connect.errors.ConnectException: Failed to find any class that implements interface org.apache.kafka.connect.rest.ConnectRestExtension and which name matches io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
replicator at org.apache.kafka.connect.runtime.isolation.Plugins.newPlugin(Plugins.java:555)
replicator at org.apache.kafka.connect.runtime.isolation.Plugins.newPlugins(Plugins.java:541)
replicator at org.apache.kafka.connect.runtime.rest.RestServer.registerRestExtensions(RestServer.java:496)
replicator at org.apache.kafka.connect.runtime.rest.ConnectRestServer.configureRegularResources(ConnectRestServer.java:70)
replicator at org.apache.kafka.connect.runtime.rest.RestServer.initializeResources(RestServer.java:232)
replicator at org.apache.kafka.connect.runtime.rest.ConnectRestServer.initializeResources(ConnectRestServer.java:46)
replicator at org.apache.kafka.connect.runtime.Connect.start(Connect.java:55)
replicator at org.apache.kafka.connect.cli.AbstractConnectCli.startConnect(AbstractConnectCli.java:168)
replicator at org.apache.kafka.connect.cli.AbstractConnectCli.run(AbstractConnectCli.java:101)
replicator at org.apache.kafka.connect.cli.ConnectDistributed.main(ConnectDistributed.java:116)
replicator [INFO] 2024-04-18 03:30:33,335 [main] org.apache.kafka.connect.runtime.Connect stop - Kafka Connect stopping```