### PR TITLE
 Fixed typo in jaas(jass) in all files of oauth dir

### DIFF
--- a/security/oauth/connectors/README.md
+++ b/security/oauth/connectors/README.md
@@ -54,7 +54,7 @@ Secrets `src-kafka-credential` and `src-kafka-credential` is used by connector t
   kubectl -n destination create secret generic src-kafka-credential \
   --from-file=plain-users.json=$TUTORIAL_HOME/creds-kafka-sasl-users.json \
   --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt 
-  kubectl -n destination create secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+  kubectl -n destination create secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
   kubectl create secret generic src-tls \
     --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/generated/server.pem \
     --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/generated/cacerts.pem \

--- a/security/oauth/connectors/confluent-platform-destination.yaml
+++ b/security/oauth/connectors/confluent-platform-destination.yaml
@@ -83,7 +83,7 @@ spec:
   authentication:
     type: oauth
     oauth:
-      secretRef: oauth-jass
+      secretRef: oauth-jaas
       configuration:
         tokenEndpointUri: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test/protocol/openid-connect/token
         expectedIssuer: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test

--- a/security/oauth/connectors/connector.yaml
+++ b/security/oauth/connectors/connector.yaml
@@ -30,7 +30,7 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test/protocol/openid-connect/token
     tls:

--- a/security/oauth/controlcenter/nonRbac/Readme.md
+++ b/security/oauth/controlcenter/nonRbac/Readme.md
@@ -24,9 +24,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/controlcenter/nonRbac/cp_components.yaml
+++ b/security/oauth/controlcenter/nonRbac/cp_components.yaml
@@ -53,7 +53,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           subClaimName: client_id
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -98,7 +98,7 @@ spec:
   authentication:
     type: oauth
     oauth:
-      secretRef: oauth-jass
+      secretRef: oauth-jaas
       configuration:
         tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
         expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -110,7 +110,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           subClaimName: client_id
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
@@ -147,7 +147,7 @@ spec:
   authentication:
     type: oauth
     oauth:
-      secretRef: oauth-jass
+      secretRef: oauth-jaas
       configuration:
         tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
         expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -159,7 +159,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           subClaimName: client_id
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
@@ -201,7 +201,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       tls:
@@ -212,7 +212,7 @@ spec:
         authentication:
           type: oauth
           oauth:
-            secretRef: oauth-jass
+            secretRef: oauth-jaas
             configuration:
               tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
         tls:
@@ -222,7 +222,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       tls:

--- a/security/oauth/controlcenter/rbac/Readme.md
+++ b/security/oauth/controlcenter/rbac/Readme.md
@@ -24,10 +24,10 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
-    kubectl -n operator create secret generic oauth-jass-oidc --from-file=oidcClientSecret.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
+    kubectl -n operator create secret generic oauth-jaas-oidc --from-file=oidcClientSecret.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/controlcenter/rbac/cp_components.yaml
+++ b/security/oauth/controlcenter/rbac/cp_components.yaml
@@ -27,7 +27,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       tls:
@@ -77,7 +77,7 @@ spec:
         sso:
           enabled: true
           clientCredentials:
-            secretRef: oauth-jass-oidc
+            secretRef: oauth-jaas-oidc
           configurations:
             groupsClaimName: profile_groups
             subClaimName: sub
@@ -101,7 +101,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -118,7 +118,7 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
 ---
@@ -148,7 +148,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -202,7 +202,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -257,7 +257,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/idp_with_certs/Readme.md
+++ b/security/oauth/idp_with_certs/Readme.md
@@ -36,9 +36,9 @@ kubectl create secret generic cacert --from-file=cacerts.pem=./$TUTORIAL_HOME/ce
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/idp_with_certs/cp_components.yaml
+++ b/security/oauth/idp_with_certs/cp_components.yaml
@@ -20,7 +20,7 @@ spec:
 # Another option is to use configOverride or jaasConfigOverride
 #  configOverrides:
 #    server:
-#      - listener.name.controller.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="${file:/mnt/secrets/oauth-jass/oauth.txt:clientId}" clientSecret="${file:/mnt/secrets/oauth-jass/oauth.txt:clientSecret}" refresh_ms="3000" ssl.truststore.location="/mnt/sslcerts/truststore.jks" ssl.truststore.password="mystorepassword" unsecuredLoginStringClaim_sub="thePrincipalName";
+#      - listener.name.controller.oauthbearer.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="${file:/mnt/secrets/oauth-jaas/oauth.txt:clientId}" clientSecret="${file:/mnt/secrets/oauth-jaas/oauth.txt:clientSecret}" refresh_ms="3000" ssl.truststore.location="/mnt/sslcerts/truststore.jks" ssl.truststore.password="mystorepassword" unsecuredLoginStringClaim_sub="thePrincipalName";
   dataVolumeCapacity: 10G
   image:
     application: confluentinc/cp-server:7.7.0
@@ -32,7 +32,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -83,7 +83,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -95,7 +95,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -123,7 +123,7 @@ spec:
         authentication:
           type: oauth
           jaasConfig:
-            secretRef: oauth-jass
+            secretRef: oauth-jaas
           oauthSettings:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
       clusterRef:
@@ -133,7 +133,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test

--- a/security/oauth/idp_with_certs/cp_components_rbac.yaml
+++ b/security/oauth/idp_with_certs/cp_components_rbac.yaml
@@ -32,7 +32,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -50,7 +50,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
       tls:
@@ -118,7 +118,7 @@ spec:
         authentication:
           type: oauth
           jaasConfig:
-            secretRef: oauth-jass
+            secretRef: oauth-jaas
           oauthSettings:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
       clusterRef:
@@ -127,7 +127,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -145,7 +145,7 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
     tls:
@@ -190,7 +190,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -247,7 +247,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test
@@ -315,7 +315,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: https://keycloak.operator.svc.cluster.local:8443/realms/sso_test

--- a/security/oauth/kafka/jaas/Readme.md
+++ b/security/oauth/kafka/jaas/Readme.md
@@ -22,9 +22,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 ```
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/kafka/jaas/cp_components.yaml
+++ b/security/oauth/kafka/jaas/cp_components.yaml
@@ -38,7 +38,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
 #          audience: api://default
           groupsClaimName: groups

--- a/security/oauth/kafka/jaas_passthrough/Readme.md
+++ b/security/oauth/kafka/jaas_passthrough/Readme.md
@@ -23,10 +23,10 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config pass through secret
+1. Create jaas config pass through secret
     ```bash
-    kubectl create -n operator secret generic pass-through-internal --from-file=oauth-jass.conf=oauth_jass_internal.txt
-    kubectl create -n operator secret generic pass-through-repl --from-file=oauth-jass.conf=oauth_jass_repl.txt
+    kubectl create -n operator secret generic pass-through-internal --from-file=oauth-jaas.conf=oauth_jaas_internal.txt
+    kubectl create -n operator secret generic pass-through-repl --from-file=oauth-jaas.conf=oauth_jaas_repl.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/kraft/nonRbac/Readme.md
+++ b/security/oauth/kraft/nonRbac/Readme.md
@@ -23,9 +23,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/kraft/nonRbac/cp_components.yaml
+++ b/security/oauth/kraft/nonRbac/cp_components.yaml
@@ -17,7 +17,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -55,7 +55,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -67,7 +67,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -95,7 +95,7 @@ spec:
         authentication:
           type: oauth
           jaasConfig:
-            secretRef: oauth-jass
+            secretRef: oauth-jaas
           oauthSettings:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       clusterRef:
@@ -105,7 +105,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/kraft/rbac/Readme.md
+++ b/security/oauth/kraft/rbac/Readme.md
@@ -23,9 +23,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/kraft/rbac/cp_components.yaml
+++ b/security/oauth/kraft/rbac/cp_components.yaml
@@ -15,7 +15,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -33,7 +33,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       tls:
@@ -88,7 +88,7 @@ spec:
         authentication:
           type: oauth
           jaasConfig:
-            secretRef: oauth-jass
+            secretRef: oauth-jaas
           oauthSettings:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       clusterRef:
@@ -97,7 +97,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/mds/oauth_with_ldap/Readme.md
+++ b/security/oauth/mds/oauth_with_ldap/Readme.md
@@ -24,9 +24,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/mds/oauth_with_ldap/cp_components.yaml
+++ b/security/oauth/mds/oauth_with_ldap/cp_components.yaml
@@ -105,7 +105,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -122,6 +122,6 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token

--- a/security/oauth/mds/only_oauth/Readme.md
+++ b/security/oauth/mds/only_oauth/Readme.md
@@ -24,9 +24,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/mds/only_oauth/cp_components.yaml
+++ b/security/oauth/mds/only_oauth/cp_components.yaml
@@ -86,7 +86,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -103,6 +103,6 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token

--- a/security/oauth/restproxy/Readme.md
+++ b/security/oauth/restproxy/Readme.md
@@ -24,9 +24,9 @@ Note that it is assumed that your Kubernetes cluster has a ``confluent`` namespa
 
 ## Deployment
 
-1. Create jass config secret
+1. Create jaas config secret
     ```bash
-    kubectl create -n operator secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl create -n operator secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     ```
 2. apply cp_components.yaml
     ```bash

--- a/security/oauth/restproxy/cp_components.yaml
+++ b/security/oauth/restproxy/cp_components.yaml
@@ -87,7 +87,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -104,7 +104,7 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
 ---
@@ -134,7 +134,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/schemalinking/README.md
+++ b/security/oauth/schemalinking/README.md
@@ -63,7 +63,7 @@ kubectl -n destination create secret tls ca-pair-sslcerts \
 ### create required secrets
     kubectl -n source create secret generic rest-credential --from-file=basic.txt=$TUTORIAL_HOME/rest-credential.txt
     kubectl -n source create secret generic password-encoder-secret --from-file=password-encoder.txt=$TUTORIAL_HOME/password-encoder-secret.txt
-    kubectl -n source create secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl -n source create secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     kubectl -n source create secret generic credential \
     --from-file=plain-users.json=$TUTORIAL_HOME/creds-kafka-sasl-users.json \
     --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \
@@ -77,7 +77,7 @@ kubectl -n destination create secret tls ca-pair-sslcerts \
 ### create required secrets
     kubectl -n destination create secret generic rest-credential --from-file=basic.txt=$TUTORIAL_HOME/rest-credential.txt
     kubectl -n destination create secret generic password-encoder-secret --from-file=password-encoder.txt=$TUTORIAL_HOME/password-encoder-secret.txt
-    kubectl -n destination create secret generic oauth-jass --from-file=oauth.txt=oauth_jass.txt
+    kubectl -n destination create secret generic oauth-jaas --from-file=oauth.txt=oauth_jaas.txt
     kubectl -n destination create secret generic credential \
     --from-file=plain-users.json=$TUTORIAL_HOME/creds-kafka-sasl-users.json \
     --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \

--- a/security/oauth/schemalinking/zk-kafka-sr-destination.yaml
+++ b/security/oauth/schemalinking/zk-kafka-sr-destination.yaml
@@ -48,7 +48,7 @@ spec:
   authentication:
     type: oauth
     oauth:
-      secretRef: oauth-jass
+      secretRef: oauth-jaas
       configuration:
         tokenEndpointUri: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test/protocol/openid-connect/token
         expectedIssuer: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test

--- a/security/oauth/schemalinking/zk-kafka-sr-source.yaml
+++ b/security/oauth/schemalinking/zk-kafka-sr-source.yaml
@@ -48,7 +48,7 @@ spec:
   authentication:
     type: oauth
     oauth:
-      secretRef: oauth-jass
+      secretRef: oauth-jaas
       configuration:
         tokenEndpointUri: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test/protocol/openid-connect/token
         expectedIssuer: http://keycloak.operator.svc.cluster.local:8080/realms/sso_test

--- a/security/oauth/upgrade/ldap_to_oauth_plus_ldap/after_1.yaml
+++ b/security/oauth/upgrade/ldap_to_oauth_plus_ldap/after_1.yaml
@@ -59,7 +59,7 @@ spec:
         sso:
           enabled: true
           clientCredentials:
-            secretRef: oauth-jass-oidc
+            secretRef: oauth-jaas-oidc
           configurations:
             groupsClaimName: profile_groups
             subClaimName: sub
@@ -83,7 +83,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/upgrade/ldap_to_oauth_plus_ldap/after_2.yaml
+++ b/security/oauth/upgrade/ldap_to_oauth_plus_ldap/after_2.yaml
@@ -28,7 +28,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
       tls:
@@ -49,7 +49,7 @@ spec:
     authentication:
       type: oauth
       oauth:
-        secretRef: oauth-jass
+        secretRef: oauth-jaas
         configuration:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
 ---
@@ -81,7 +81,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -137,7 +137,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test
@@ -195,7 +195,7 @@ spec:
       authentication:
         type: oauth
         oauth:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
           configuration:
             tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
             expectedIssuer: http://keycloak:8080/realms/sso_test

--- a/security/oauth/upgrade/ldap_to_oauth_plus_ldap/before.yaml
+++ b/security/oauth/upgrade/ldap_to_oauth_plus_ldap/before.yaml
@@ -102,7 +102,7 @@ spec:
         oidc:
           enabled: true
           clientCredentials:
-            secretRef: oauth-jass-oidc
+            secretRef: oauth-jaas-oidc
           configurations:
             groupsClaimName: profile_groups
             subClaimName: sub

--- a/security/oauth/upgrade/ldap_to_oauth_plus_ldap/before_76.yaml
+++ b/security/oauth/upgrade/ldap_to_oauth_plus_ldap/before_76.yaml
@@ -102,7 +102,7 @@ spec:
         oidc:
           enabled: true
           clientCredentials:
-            secretRef: oauth-jass-oidc
+            secretRef: oauth-jaas-oidc
           configurations:
             groupsClaimName: profile_groups
             subClaimName: sub

--- a/security/oauth/upgrade/oauth_plus_ldap_to_just_oauth/just_oauth.yaml
+++ b/security/oauth/upgrade/oauth_plus_ldap_to_just_oauth/just_oauth.yaml
@@ -41,7 +41,7 @@ spec:
         sso:
           enabled: true
           clientCredentials:
-            secretRef: oauth-jass-oidc
+            secretRef: oauth-jaas-oidc
           configurations:
             groupsClaimName: profile_groups
             subClaimName: sub
@@ -65,7 +65,7 @@ spec:
       authentication:
         type: oauth
         jaasConfig:
-          secretRef: oauth-jass
+          secretRef: oauth-jaas
         oauthSettings:
           tokenEndpointUri: http://keycloak:8080/realms/sso_test/protocol/openid-connect/token
           expectedIssuer: http://keycloak:8080/realms/sso_test


### PR DESCRIPTION
There is typo in **jaas** (as _jass_) at all the places at https://github.com/confluentinc/confluent-kubernetes-examples/tree/master/security/oauth

Fixed it in all the yaml files and documentation. 