### PR TITLE
replicator connect cluster should use connect.protocol=eager

### DIFF
--- a/hybrid/replicator-cloud2cloud/components-destination.yaml
+++ b/hybrid/replicator-cloud2cloud/components-destination.yaml
@@ -19,6 +19,8 @@ spec:
       - rest.extension.classes=io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
       # This specifies that Replicator is the Connector configured
       - connector.class=io.confluent.connect.replicator.ReplicatorSourceConnector
+      # To prevent duplicate replicator tasks use eager
+      - connect.protocol=eager
   dependencies:
     kafka:
       bootstrapEndpoint: <destination-ccloud-endpoint:9092>

--- a/hybrid/replicator-source-ccloud-destCFK-tls/components-destination.yaml
+++ b/hybrid/replicator-source-ccloud-destCFK-tls/components-destination.yaml
@@ -98,6 +98,8 @@ spec:
       - rest.extension.classes=io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
       # This specifies that Replicator is the Connector configured
       - connector.class=io.confluent.connect.replicator.ReplicatorSourceConnector
+      # To prevent duplicate replicator tasks use eager 
+      - connect.protocol=eager
   dependencies:
     kafka:
       bootstrapEndpoint: kafka.destination.svc.cluster.local:9071

--- a/hybrid/replicator/components-destination.yaml
+++ b/hybrid/replicator/components-destination.yaml
@@ -130,6 +130,8 @@ spec:
       - rest.extension.classes=io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
       # This specifies that Replicator is the Connector configured
       - connector.class=io.confluent.connect.replicator.ReplicatorSourceConnector
+      # To prevent duplicate replicator tasks use eager
+      - connect.protocol=eager
   dependencies:
     kafka:
       bootstrapEndpoint: kafka.destination.svc.cluster.local:9071


### PR DESCRIPTION
Replicator has the following limitation:

When running Replicator with version 5.3.0 or above, set connect.protocol=eager as there is a known issue where using the default of connect.protocol=compatible or connect.protocol=sessioned can cause issues with tasks rebalancing and duplicate records.

Reference: 
https://docs.confluent.io/platform/current/multi-dc-deployments/replicator/index.html#known-issues-limitations-and-best-practices

We should take this to account and have connect.protocol=eager on the connect worker overrides.