### PR TITLE
[CFK-3556] | Add playbook to support file based userStore with Vault

### DIFF
--- a/assets/certs/component-certs/README.md
+++ b/assets/certs/component-certs/README.md
@@ -84,6 +84,14 @@ cfssl gencert -ca=$TUTORIAL_HOME/generated/cacerts.pem \
 -config=$TUTORIAL_HOME/ca-config.json \
 -profile=server $TUTORIAL_HOME/kafka-server-domain.json | cfssljson -bare $TUTORIAL_HOME/generated/kafka-server
 
+# Create Kraft server certificates
+# Use the SANs listed in kraft-server-domain.json
+
+cfssl gencert -ca=$TUTORIAL_HOME/generated/cacerts.pem \
+-ca-key=$TUTORIAL_HOME/generated/rootCAkey.pem \
+-config=$TUTORIAL_HOME/ca-config.json \
+-profile=server $TUTORIAL_HOME/kraft-server-domain.json | cfssljson -bare $TUTORIAL_HOME/generated/kraft-server
+
 # Create ControlCenter server certificates
 # Use the SANs listed in controlcenter-server-domain.json
 

--- a/assets/certs/component-certs/kraft-server-domain.json
+++ b/assets/certs/component-certs/kraft-server-domain.json
@@ -1,14 +1,14 @@
 {
-  "CN": "kraft",
+  "CN": "kraftcontroller",
   "hosts": [
-    "kraft",
+    "kraftcontroller",
     "*.my.domain",
-    "kraft.confluent.svc.cluster.local",
-    "*.kraft.confluent.svc.cluster.local",
-    "kraft.source.svc.cluster.local",
-    "*.kraft.source.svc.cluster.local",
-    "kraft.destination.svc.cluster.local",
-    "*.kraft.destination.svc.cluster.local"
+    "kraftcontroller.confluent.svc.cluster.local",
+    "*.kraftcontroller.confluent.svc.cluster.local",
+    "kraftcontroller.source.svc.cluster.local",
+    "*.kraftcontroller.source.svc.cluster.local",
+    "kraftcontroller.destination.svc.cluster.local",
+    "*.kraftcontroller.destination.svc.cluster.local"
   ],
   "key": {
     "algo": "rsa",

--- a/assets/certs/component-certs/kraft-server-domain.json
+++ b/assets/certs/component-certs/kraft-server-domain.json
@@ -1,0 +1,24 @@
+{
+  "CN": "kraft",
+  "hosts": [
+    "kraft",
+    "*.my.domain",
+    "kraft.confluent.svc.cluster.local",
+    "*.kraft.confluent.svc.cluster.local",
+    "kraft.source.svc.cluster.local",
+    "*.kraft.source.svc.cluster.local",
+    "kraft.destination.svc.cluster.local",
+    "*.kraft.destination.svc.cluster.local"
+  ],
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "Universe",
+      "ST": "Pangea",
+      "L": "Earth"
+    }
+  ]
+}

--- a/security/mds-mtls-with-vault/README.md
+++ b/security/mds-mtls-with-vault/README.md
@@ -124,7 +124,7 @@ helm repo update
 
 * Install Confluent For Kubernetes using Helm:
 ```
-helm upgrade --install confluent-operator confluentinc/confluent-for-kubernetes
+helm upgrade --install confluent-operator confluentinc/confluent-for-kubernetes -n confluent
 ```
 
 The `confluent-sa` Service Account will be associated with our deployment of Confluent Platform,
@@ -188,6 +188,12 @@ and set the appropriate SANs.
 ## Provide component TLS certificates
 
 ```
+kubectl create secret generic tls-kraft \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kraft-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kraft-server-key.pem \
+  --namespace confluent
+
 kubectl create secret generic tls-kafka \
   --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kafka-server.pem \
   --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \

--- a/security/mds-mtls-with-vault/README.md
+++ b/security/mds-mtls-with-vault/README.md
@@ -1,0 +1,336 @@
+# Security setup
+
+In this workflow scenario, you'll set up a Confluent Platform cluster with the following security:
+- Full TLS network encryption with user provided certificates
+- mTLS authentication on MDS Server for RBAC, along with mTLS on all cp components
+- File Based User Store in MDS for Confluent Control Center user credentials
+
+# Managing user store credentials in HashiCorp Vault
+In this example, we will use secret stored in vault for file based User Store in MDS
+
+## Set the current tutorial directory
+
+Set the tutorial directory for this tutorial under the directory you downloaded the tutorial files:
+
+```
+export TUTORIAL_HOME=<Tutorial directory>/security/mds-mtls-with-vault
+```
+
+
+## Configure Hashicorp Vault
+
+Note: Hashicorp Vault is a third party software product that is not supported or distributed by Confluent. In this scenario, you will deploy and configure Hashicorp Vault in a way to support this scenario. There are multiple ways to configure and use Hashicorp Vault - follow their product docs for that information.
+
+### Install Vault
+
+Using the Helm Chart, install the latest version of the Vault server running in development mode to a namespace `hashicorp`.
+
+Running a Vault server in development is automatically initialized and unsealed. This is ideal in a learning environment, but not recommended for a production environment.
+
+```
+kubectl create ns hashicorp
+
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm upgrade --install vault --set='server.dev.enabled=true' hashicorp/vault -n hashicorp
+```
+
+Once installed, you should see two pods:
+
+```
+kubectl get pods -n hashicorp
+NAME                                    READY   STATUS    RESTARTS   AGE
+vault-0                                 1/1     Running   0          23s
+vault-agent-injector-85b7b88795-q5vcp   1/1     Running   0          24s
+```
+
+
+### Initialize Vault authentication
+
+Open an interactive shell session in the Vault container:
+
+```
+kubectl exec -it vault-0 -n hashicorp -- /bin/sh
+```
+
+Instruct Vault to treat Kubernetes as a trusted identity provider for authentication to Vault:
+
+```
+/ $ vault auth enable kubernetes
+```
+
+Configure Vault to know how to connect to the Kubernetes API (the API of the very same Kubernetes cluster where Vault is deployed) to authenticate requests made to Vault by a principal whose identity is tied to Kubernetes, such as a Kubernetes Service Account.
+
+```
+/ $ vault write auth/kubernetes/config \
+    token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
+    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+```
+
+
+### Configure Vault Policy
+
+Create a Vault policy file for all secrets stored in path `/secret/`:
+
+```
+cat <<EOF > $TUTORIAL_HOME/app-policy.hcl
+path "secret*" {
+capabilities = ["read"]
+}
+EOF
+```
+
+Copy the app policy file to the Vault pod:
+
+```
+## Coopy the file to the /tmp location on the Vault pod disk
+kubectl -n hashicorp cp $TUTORIAL_HOME/app-policy.hcl vault-0:/tmp
+```
+
+Open an interactive shell session in the Vault container and apply the policy:
+
+```
+kubectl exec -it vault-0 -n hashicorp -- /bin/sh
+
+/ $ vault write sys/policy/app policy=@/tmp/app-policy.hcl
+```
+
+Then, grant the `confluent-sa` Service Account access to all secrets stored in path `/secret`
+by binding it to the above policy. We’ll create the Service Account in the following step
+when we prepare to deploy Confluent Platform, but we can perform the policy binding now
+while we’re still in the Vault shell:
+
+```
+vault write auth/kubernetes/role/confluent-operator \
+    bound_service_account_names=confluent-sa \
+    bound_service_account_namespaces=confluent \
+    policies=app \
+    ttl=24h
+```
+
+## Create confluent Namespace
+```
+kubectl create namespace confluent
+kubectl create serviceaccount confluent-sa -n confluent
+```
+
+## Deploy Confluent for Kubernetes
+
+* Set up the Helm Chart:
+```
+helm repo add confluentinc https://packages.confluent.io/helm
+helm repo update
+```
+
+* Install Confluent For Kubernetes using Helm:
+```
+helm upgrade --install confluent-operator confluentinc/confluent-for-kubernetes
+```
+
+The `confluent-sa` Service Account will be associated with our deployment of Confluent Platform,
+enabling it to access the secrets that we stored in Vault.
+
+## Write credentials in Vault
+
+In this next set of steps, you will take user store credentials and store them in Vault.
+
+The file $TUTORIAL_HOME/fileUserPassword.txt contains file based username/password.
+The users must be added in the format <username>:<password>
+For your deployment, you'll edit these files to incorporate your credentials.
+
+Copy the credential files directory and its contents to a directory in the Vault pod. In
+this scenario example, you'll use `/tmp` as the parent directory. You can change this
+as desired.
+```
+kubectl -n hashicorp cp $TUTORIAL_HOME/fileUserPassword.txt vault-0:/tmp
+```
+Open an interactive shell session in the Vault container:
+
+```
+kubectl exec -it vault-0 -n hashicorp -- /bin/sh
+```
+
+Write the credentials to Vault:
+
+```
+cat /tmp/fileUserPassword.txt | base64 | vault kv put /secret/fileuser.txt fileuser=-
+```
+
+## Create TLS certificates
+
+In this scenario, you'll configure authentication using the mTLS mechanism. With mTLS, Confluent components and clients use TLS certificates for authentication. The certificate has a CN that identifies the principal name.
+
+Each Confluent component service should have its own TLS certificate. In this scenario, you'll
+generate a server certificate for each Confluent component service. Follow [these instructions](../assets/certs/component-certs/README.md) to generate these certificates.
+
+## Deploy configuration secrets
+
+You'll use Kubernetes secrets to provide credential configurations.
+
+With Kubernetes secrets, credential management (defining, configuring, updating)
+can be done outside of the Confluent For Kubernetes. You define the configuration
+secret, and then tell Confluent For Kubernetes where to find the configuration.
+
+To support the above deployment scenario, you need to provide the following
+credentials:
+
+* Component TLS Certificates. The principal extracted from these certificates will be used for Authentication
+
+* File Based User Credentials
+
+* RBAC principal credentials
+
+You can either provide your own certificates, or generate test certificates. Follow instructions
+in the below `Appendix: Create your own certificates` section to see how to generate certificates
+and set the appropriate SANs.
+
+
+## Provide component TLS certificates
+
+```
+kubectl create secret generic tls-kafka \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kafka-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kafka-server-key.pem \
+  --namespace confluent
+
+kubectl create secret generic tls-controlcenter \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/controlcenter-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/controlcenter-server-key.pem \
+  --namespace confluent
+
+kubectl create secret generic tls-schemaregistry \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/schemaregistry-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/schemaregistry-server-key.pem \
+  --namespace confluent
+
+kubectl create secret generic tls-connect \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/connect-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/connect-server-key.pem \
+  --namespace confluent
+  
+kubectl create secret generic tls-kafkarestproxy \
+  --from-file=fullchain.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kafkarestproxy-server.pem \
+  --from-file=cacerts.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/cacerts.pem \
+  --from-file=privkey.pem=$TUTORIAL_HOME/../../assets/certs/component-certs/generated/kafkarestproxy-server-key.pem \
+  --namespace confluent
+
+```
+
+## Provide RBAC principal credentials
+
+* Create a Kubernetes secret object for MDS:
+
+```
+kubectl create secret generic mds-token \
+--from-file=mdsPublicKey.pem=$TUTORIAL_HOME/../../assets/certs/mds-publickey.txt \
+--from-file=mdsTokenKeyPair.pem=$TUTORIAL_HOME/../../assets/certs/mds-tokenkeypair.txt \
+-n confluent
+```
+
+## Deploy Confluent Platform
+
+* Deploy Confluent Platform
+```
+kubectl apply -f $TUTORIAL_HOME/confluent-platform.yaml
+```
+
+* Check that all Confluent Platform resources are deployed:
+
+```
+kubectl get pods -n confluent
+```
+
+## Create RBAC Rolebindings for Control Center user
+
+```
+kubectl apply -f $TUTORIAL_HOME/controlcenter-rolebinding.yaml
+```
+
+## Validate
+
+### Validate in Control Center
+
+Use Control Center to monitor the Confluent Platform. You can visit the external URL you set up for Control Center, or visit the URL through a local port forwarding like below:
+
+* Set up port forwarding to Control Center web UI from local machine:
+
+```
+kubectl port-forward controlcenter-0 9021:9021 -n confluent
+```
+
+* Browse to Control Center, use the credentials testuser1 as user, and password1 as password to login to Control Center.
+```
+https://localhost:9021
+```
+
+## Tear down
+
+```
+kubectl delete confluentrolebinding --all -n confluent
+kubectl delete -f $TUTORIAL_HOME/confluent-platform.yaml -n confluent
+kubectl delete secret mds-token -n confluent
+kubectl delete secret tls-kafka tls-connect tls-schemaregistry tls-kafkarestproxy tls-controlcenter --namespace confluent
+helm delete confluent-operator -n confluent
+helm delete vault -n hashicorp
+```
+
+## Appendix: Troubleshooting
+
+In this scenario, for each Kafka component pod, there will be multiple containers included:
+
+- CP component container (for example `kafka`)
+- Vault agent (`vault-agent`)
+- CP component init container (`config-init-container`)
+- Vault agent init container (`vault-agent-init`)
+
+To get logs for debugging, you'll need to specify the container name. For example, to get
+`kafka` pod containerlogs:
+
+```
+kubectl logs kafka-0 -c vault-agent-init
+kubectl logs kafka-0 -c kafka
+kubectl logs kafka-0 -c vault-agent
+```
+
+## Appendix: Create your own certificates
+
+When testing, it's often helpful to generate your own certificates to validate the architecture and deployment. You'll want both these to be represented in the certificate SAN:
+
+* external domain names
+* internal Kubernetes domain names
+* Install libraries on Mac OS
+
+The internal Kubernetes domain name depends on the namespace you deploy to. If you deploy to confluent namespace, then the internal domain names will be:
+* .kraftcontroller.confluent.svc.cluster.local
+* .kafka.confluent.svc.cluster.local
+* .confluent.svc.cluster.local
+
+Create your certificates by following the steps:
+* Install libraries on Mac OS
+```
+brew install cfssl
+```
+* Create Certificate Authority
+```
+mkdir $TUTORIAL_HOME/../assets/certs/generated && cfssl gencert -initca $TUTORIAL_HOME/../assets/certs/ca-csr.json | cfssljson -bare $TUTORIAL_HOME/../assets/certs/generated/ca -
+```
+* Validate Certificate Authority
+```
+openssl x509 -in $TUTORIAL_HOME/../assets/certs/generated/ca.pem -text -noout
+```
+* Create server certificates with the appropriate SANs (SANs listed in server-domain.json)
+```
+cfssl gencert -ca=$TUTORIAL_HOME/../assets/certs/generated/ca.pem \
+-ca-key=$TUTORIAL_HOME/../assets/certs/generated/ca-key.pem \
+-config=$TUTORIAL_HOME/../assets/certs/ca-config.json \
+-profile=server $TUTORIAL_HOME/../assets/certs/server-domain.json | cfssljson -bare $TUTORIAL_HOME/../assets/certs/generated/server
+``` 
+
+* Validate server certificate and SANs
+```
+openssl x509 -in $TUTORIAL_HOME/../assets/certs/generated/server.pem -text -noout
+```

--- a/security/mds-mtls-with-vault/app-policy.hcl
+++ b/security/mds-mtls-with-vault/app-policy.hcl
@@ -1,0 +1,3 @@
+path "secret*" {
+capabilities = ["read"]
+}

--- a/security/mds-mtls-with-vault/confluent-platform.yaml
+++ b/security/mds-mtls-with-vault/confluent-platform.yaml
@@ -21,6 +21,7 @@ spec:
     type: rbac
     superUsers:
       - User:kafka
+      - User:kraftcontroller
   dependencies:
     mdsKafkaCluster:
       bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
@@ -59,6 +60,7 @@ spec:
     type: rbac
     superUsers:
       - User:kafka
+      - User:kraftcontroller
   replicas: 3
   image:
     application: confluentinc/cp-server:7.8.0

--- a/security/mds-mtls-with-vault/confluent-platform.yaml
+++ b/security/mds-mtls-with-vault/confluent-platform.yaml
@@ -30,7 +30,7 @@ spec:
       tls:
         enabled: true
   tls:
-    secretRef: tls-kafka
+    secretRef: tls-kraft
   replicas: 3
 ---
 apiVersion: platform.confluent.io/v1beta1

--- a/security/mds-mtls-with-vault/confluent-platform.yaml
+++ b/security/mds-mtls-with-vault/confluent-platform.yaml
@@ -1,0 +1,316 @@
+apiVersion: platform.confluent.io/v1beta1
+kind: KRaftController
+metadata:
+  name: kraftcontroller
+  namespace: confluent
+spec:
+  dataVolumeCapacity: 10Gi
+  image:
+    application: confluentinc/cp-server:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  listeners:
+    controller:
+      authentication:
+        type: mtls
+        principalMappingRules:
+          - "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/"
+          - "DEFAULT"
+      tls:
+        enabled: true
+  authorization:
+    type: rbac
+    superUsers:
+      - User:kafka
+  dependencies:
+    mdsKafkaCluster:
+      bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+  tls:
+    secretRef: tls-kafka
+  replicas: 3
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: Kafka
+metadata:
+  name: kafka
+  namespace: confluent
+spec:
+  podTemplate:
+    serviceAccountName: confluent-sa
+    annotations:
+      vault.hashicorp.com/agent-inject: "true"
+      vault.hashicorp.com/agent-inject-status: update
+      vault.hashicorp.com/preserve-secret-case: "true"
+      vault.hashicorp.com/agent-inject-secret-fileuser.txt: secret/fileuser.txt
+      vault.hashicorp.com/agent-inject-template-fileuser.txt: |
+        {{- with secret "secret/fileuser.txt" -}}
+        {{ .Data.data.fileuser | base64Decode }}
+        {{- end }}
+      vault.hashicorp.com/role: confluent-operator
+  configOverrides:
+    server:
+      - confluent.metadata.server.user.store=FILE
+      - confluent.metadata.server.user.store.file.path=/vault/secrets/fileuser.txt
+  authorization:
+    type: rbac
+    superUsers:
+      - User:kafka
+  replicas: 3
+  image:
+    application: confluentinc/cp-server:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  dataVolumeCapacity: 10Gi
+  tls:
+    secretRef: tls-kafka
+  listeners:
+    internal:
+      authentication:
+        type: mtls
+        principalMappingRules:
+          - "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/"
+          - "DEFAULT"
+      tls:
+        enabled: true
+    external:
+      authentication:
+        type: mtls
+        principalMappingRules:
+          - "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/"
+          - "DEFAULT"
+      tls:
+        enabled: true
+  metricReporter:
+    enabled: true
+    authentication:
+      type: mtls
+    tls:
+      enabled: true
+  services:
+    mds:
+      impersonation:
+        admins:
+          - User:kafka
+          - User:krp # kafkarestproxy principal should always be added as impersonation admin
+          # - User:connect # need to add this as impersonation admin when Connect has multiple nodes
+          #- User:sr # need to add this as impersonation admin when SR has multiple nodes
+      tls:
+        enabled: true
+      tokenKeyPair:
+        secretRef: mds-token
+      provider:
+        mtls:
+          sslClientAuthentication: "required"
+          principalMappingRules:
+            - "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/"
+            - "DEFAULT"
+  dependencies:
+    kafkaRest:
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+        secretRef: tls-kafka
+    kRaftController:
+      controllerListener:
+        tls:
+          enabled: true
+        authentication:
+          type: mtls
+      clusterRef:
+        name: kraftcontroller
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestProxy
+metadata:
+  name: kafkarestproxy
+  namespace: confluent
+spec:
+  replicas: 1
+  image:
+    application: confluentinc/cp-kafka-rest:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  tls:
+    secretRef: tls-kafkarestproxy
+  authorization:
+    type: rbac
+  authentication:
+    type: mtls
+    mtls:
+      sslClientAuthentication: "required"
+      principalMappingRules:
+        - "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/"
+        - "DEFAULT"
+  dependencies:
+    kafka:
+      bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    mds:
+      endpoint: https://kafka.confluent.svc.cluster.local:8090
+      tokenKeyPair:
+        secretRef: mds-token
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    schemaRegistry:
+      url: https://schemaregistry.confluent.svc.cluster.local:8081
+      authentication:
+        type: mtls
+      tls:
+        enabled: true
+    interceptor:
+      enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: ControlCenter
+metadata:
+  name: controlcenter
+  namespace: confluent
+spec:
+  authorization:
+    type: rbac
+  replicas: 1
+  image:
+    application: confluentinc/cp-enterprise-control-center:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  dataVolumeCapacity: 10Gi
+  tls:
+    secretRef: tls-controlcenter
+  dependencies:
+    kafka:
+      bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
+      authentication:
+        type: mtls
+      tls:
+        enabled: true
+    mds:
+      endpoint: https://kafka.confluent.svc.cluster.local:8090
+      tokenKeyPair:
+        secretRef: mds-token
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    schemaRegistry:
+      url: https://schemaregistry.confluent.svc.cluster.local:8081
+      authentication:
+        type: mtls
+      tls:
+        enabled: true
+    connect:
+      - name: connect
+        url: https://connect.confluent.svc.cluster.local:8083
+        authentication:
+          type: mtls
+        tls:
+          enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: SchemaRegistry
+metadata:
+  name: schemaregistry
+  namespace: confluent
+spec:
+  replicas: 1
+  image:
+    application: confluentinc/cp-schema-registry:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  tls:
+    secretRef: tls-schemaregistry
+  authorization:
+    type: rbac
+  authentication:
+    type: mtls
+    mtls:
+      sslClientAuthentication: "required"
+      principalMappingRules: [ "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/" ,"RULE:.*CN=([a-zA-Z0-9]*).*$/$1/", "DEFAULT" ]
+  dependencies:
+    kafka:
+      bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    mds:
+      endpoint: https://kafka.confluent.svc.cluster.local:8090
+      tokenKeyPair:
+        secretRef: mds-token
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: Connect
+metadata:
+  name: connect
+  namespace: confluent
+spec:
+  replicas: 1
+  image:
+    application: confluentinc/cp-server-connect:7.8.0
+    init: confluentinc/confluent-init-container:2.10.0
+  tls:
+    secretRef: tls-connect
+  authorization:
+    type: rbac
+  authentication:
+    type: mtls
+    mtls:
+      sslClientAuthentication: "required"
+      principalMappingRules: [ "RULE:.*CN=([a-zA-Z0-9.-]*).*$/$1/" , "DEFAULT" ]
+  dependencies:
+    kafka:
+      bootstrapEndpoint: kafka.confluent.svc.cluster.local:9071
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    mds:
+      endpoint: https://kafka.confluent.svc.cluster.local:8090
+      tokenKeyPair:
+        secretRef: mds-token
+      authentication:
+        type: mtls
+        sslClientAuthentication: true
+      tls:
+        enabled: true
+    schemaRegistry:
+      url: https://schemaregistry.confluent.svc.cluster.local:8081
+      authentication:
+        type: mtls
+      tls:
+        enabled: true
+    interceptor:
+      enabled: true
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestClass
+metadata:
+  name: default
+  namespace: confluent
+spec:
+  kafkaClusterRef:
+    name: kafka
+    namespace: confluent
+  kafkaRest:
+    endpoint: https://kafka.confluent.svc.cluster.local:8090
+    authentication:
+      type: mtls
+      sslClientAuthentication: true
+    tls:
+      secretRef: tls-kafka

--- a/security/mds-mtls-with-vault/controlcenter-rolebinding.yaml
+++ b/security/mds-mtls-with-vault/controlcenter-rolebinding.yaml
@@ -1,0 +1,48 @@
+---
+# rolebinding `testuser-rb` allows `testuser1` to see kafkaCluster
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: testuser-rb
+  namespace: confluent
+spec:
+  principal:
+    type: user
+    name: testuser1
+  role: ClusterAdmin
+  ## if use other kafkaRestClass except for default, need to configure accordingly
+  #kafkaRestClassRef:
+  # name: default
+---
+# rolebinding `testuser-rb-sr` allows `testuser1` to see schemaregistry information
+# `schemaRegistryCllusterId` pattern: `id_<schemaregistry.name>_<namespace>`
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: testuser-rb-sr
+  namespace: confluent
+spec:
+  # The Schema Registry cluster is named `schemaregistry` and is deployed in the
+  # namespace `confluent`
+  # The Schema Registry cluster id naming pattern is: id_<sr-cluster-name>_<namespace>
+  clustersScopeByIds:
+    schemaRegistryClusterId: id_schemaregistry_confluent
+  principal:
+    name: testuser1
+    type: user
+  role: SystemAdmin
+---
+# rolebinding `testuser-rb-connect` allows `testuser1` to see connect cluster
+# `connectClusterId` pattern: `<namespace>.<connect.name>`
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: testuser-rb-connect
+  namespace: confluent
+spec:
+  principal:
+    type: user
+    name: testuser1
+  clustersScopeByIds:
+    connectClusterId: confluent.connect
+  role: SystemAdmin

--- a/security/mds-mtls-with-vault/fileUserPassword.txt
+++ b/security/mds-mtls-with-vault/fileUserPassword.txt
@@ -1,0 +1,2 @@
+testuser1:password1
+testuser2:password2


### PR DESCRIPTION
This PR adds example playbook to configure file based user store with secrets stored in Vault.

Kafka containers:
<img width="1313" alt="Screenshot 2025-01-27 at 5 23 58 PM" src="https://github.com/user-attachments/assets/bd53adb0-49d1-4dcb-9d49-0b9da7a3a905" />

kafka config map which refers to the mounted path:
<img width="958" alt="Screenshot 2025-01-27 at 5 25 07 PM" src="https://github.com/user-attachments/assets/5dfff33d-03f3-4392-9aaf-d6cb2c54eea3" />

Control center login with credentials stored in vault (for example, testuser1 password1 here)
<img width="1499" alt="Screenshot 2025-01-27 at 5 31 27 PM" src="https://github.com/user-attachments/assets/eb7131c8-77b1-4dcd-9d6d-91719ede550b" />
