### PR TITLE
[CFK-3616] | enable auth in keycloak setup

### DIFF
--- a/assets/certs/component-certs/kafka-server-domain.json
+++ b/assets/certs/component-certs/kafka-server-domain.json
@@ -12,7 +12,9 @@
     "zookeeper.source.svc.cluster.local",
     "*.zookeeper.source.svc.cluster.local",
     "zookeeper.destination.svc.cluster.local",
-    "*.zookeeper.destination.svc.cluster.local"
+    "*.zookeeper.destination.svc.cluster.local",
+    "kraftcontroller.confluent.svc.cluster.local",
+    "*.kraftcontroller.confluent.svc.cluster.local"
   ],
   "key": {
     "algo": "rsa",

--- a/security/mds-mtls-c3-sso/keycloak.yaml
+++ b/security/mds-mtls-c3-sso/keycloak.yaml
@@ -793,6 +793,7 @@ data:
           "implicitFlowEnabled": false,
           "directAccessGrantsEnabled": true,
           "serviceAccountsEnabled": false,
+          "authorizationServicesEnabled": true,
           "publicClient": false,
           "frontchannelLogout": true,
           "protocol": "openid-connect",


### PR DESCRIPTION
In our test keycloak setup, we need to manually enable authorization. This PR adds config to enable it by default. Currently only added for mtls+oauth example so as to not affect other setups.
In some of our mtls tests, we are using the same tls secret for kafka and kraft. Due to this, we also need to add kraft SN in broker's json file