### PR TITLE
Changing oidc to sso

### DIFF
--- a/security/control-center-sso/confluent-platform.yaml
+++ b/security/control-center-sso/confluent-platform.yaml
@@ -73,7 +73,7 @@ spec:
             userObjectClass: organizationalRole
             userSearchBase: dc=test,dc=com
             userSearchScope: 1
-        oidc:
+        sso:
           clientCredentials:
             secretRef: credential
           configurations:


### PR DESCRIPTION
changed oidc to sso in the Kafka CR as oidc attribute is [deprecated](https://docs.confluent.io/operator/current/co-authenticate-cp.html#co-authenticate-c3-sso:~:text=for%20example%20configurations.-,%5B4%5D%20Deprecated.,-For%20backward%20compatibility) 