### PR TITLE
CFK-3990 Fix kraft migration example for rbac enabled clusters

### DIFF
--- a/migration/KRaftMigration/rbac-enabled-cluster/README.md
+++ b/migration/KRaftMigration/rbac-enabled-cluster/README.md
@@ -19,6 +19,12 @@ export TUTORIAL_HOME=<Tutorial directory>/migration/KRaftMigration/rbac-enabled-
 
 ## Deploy Confluent for Kubernetes
 
+* Create the namespace to use
+```
+kubectl create namespace confluent
+```
+
+
 * Set up the Helm Chart:
 ```
 helm repo add confluentinc https://packages.confluent.io/helm
@@ -41,7 +47,7 @@ This repo includes a Helm chart for [OpenLdap](https://github.com/osixia/docker-
 
 * Deploy OpenLdap
 ```
-helm upgrade --install -f $TUTORIAL_HOME/../../../assets/openldap/ldaps-rbac.yaml test-ldap $TUTORIAL_HOME/../../assets/openldap --namespace confluent
+helm upgrade --install -f $TUTORIAL_HOME/../../../assets/openldap/ldaps-rbac.yaml test-ldap $TUTORIAL_HOME/../../../assets/openldap --namespace confluent
 ```
 
 * Validate that OpenLDAP is running:

--- a/migration/KRaftMigration/rbac-enabled-cluster/README.md
+++ b/migration/KRaftMigration/rbac-enabled-cluster/README.md
@@ -112,13 +112,6 @@ kubectl create secret generic credential \
 --from-file=digest.txt=$TUTORIAL_HOME/creds-kafka-zookeeper-credentials.txt \
 --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \
 --from-file=ldap.txt=$TUTORIAL_HOME/ldap.txt \
---from-file=plain-interbroker.txt=$TUTORIAL_HOME/creds/creds-client-kafka-sasl-user.txt \
---namespace confluent
-```
-
-```
-kubectl create secret generic credential-plain \
---from-file=plain-jaas.conf=$TUTORIAL_HOME/creds-kafka-sasl-users.conf \
 --namespace confluent
 ```
 

--- a/migration/KRaftMigration/rbac-enabled-cluster/README.md
+++ b/migration/KRaftMigration/rbac-enabled-cluster/README.md
@@ -112,6 +112,13 @@ kubectl create secret generic credential \
 --from-file=digest.txt=$TUTORIAL_HOME/creds-kafka-zookeeper-credentials.txt \
 --from-file=plain.txt=$TUTORIAL_HOME/creds-client-kafka-sasl-user.txt \
 --from-file=ldap.txt=$TUTORIAL_HOME/ldap.txt \
+--from-file=plain-interbroker.txt=$TUTORIAL_HOME/creds/creds-client-kafka-sasl-user.txt \
+--namespace confluent
+```
+
+```
+kubectl create secret generic credential-plain \
+--from-file=plain-jaas.conf=$TUTORIAL_HOME/creds-kafka-sasl-users.conf \
 --namespace confluent
 ```
 

--- a/migration/KRaftMigration/rbac-enabled-cluster/confluent-platform.yaml
+++ b/migration/KRaftMigration/rbac-enabled-cluster/confluent-platform.yaml
@@ -15,14 +15,14 @@ spec:
   listeners:
     internal:
       authentication:
-        type: plain
+        type: ldap
         jaasConfig:
           secretRef: credential
       tls:
         enabled: true
     external:
       authentication:
-        type: plain
+        type: ldap
         jaasConfig:
           secretRef: credential
       externalAccess:
@@ -97,6 +97,14 @@ spec:
     init: confluentinc/confluent-init-container:2.11.0
   tls:
     secretRef: tls-group1
+  listeners:
+    controller:
+      authentication:
+        type: plain
+        jaasConfigPassThrough:
+          secretRef: credential-plain
+      tls:
+        enabled: true
   dataVolumeCapacity: 10G
   authorization:
     superUsers:

--- a/migration/KRaftMigration/rbac-enabled-cluster/confluent-platform.yaml
+++ b/migration/KRaftMigration/rbac-enabled-cluster/confluent-platform.yaml
@@ -15,14 +15,14 @@ spec:
   listeners:
     internal:
       authentication:
-        type: ldap
+        type: plain
         jaasConfig:
           secretRef: credential
       tls:
         enabled: true
     external:
       authentication:
-        type: ldap
+        type: plain
         jaasConfig:
           secretRef: credential
       externalAccess:
@@ -101,8 +101,8 @@ spec:
     controller:
       authentication:
         type: plain
-        jaasConfigPassThrough:
-          secretRef: credential-plain
+        jaasConfig:
+          secretRef: credential
       tls:
         enabled: true
   dataVolumeCapacity: 10G

--- a/migration/KRaftMigration/rbac-enabled-cluster/creds-kafka-sasl-users.conf
+++ b/migration/KRaftMigration/rbac-enabled-cluster/creds-kafka-sasl-users.conf
@@ -1,4 +1,0 @@
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
- username="kafka" \
- password="kafka-secret" \
- user_kafka="kafka-secret";

--- a/migration/KRaftMigration/rbac-enabled-cluster/creds-kafka-sasl-users.conf
+++ b/migration/KRaftMigration/rbac-enabled-cluster/creds-kafka-sasl-users.conf
@@ -1,0 +1,4 @@
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+ username="kafka" \
+ password="kafka-secret" \
+ user_kafka="kafka-secret";


### PR DESCRIPTION
[KRaft migration example for RBAC-enabled clusters](https://github.com/confluentinc/confluent-kubernetes-examples/tree/master/migration/KRaftMigration/rbac-enabled-cluster) didn't work, its throwing below error - 
```
org.apache.kafka.common.errors.ClusterAuthorizationException: Received cluster authorization error in response InboundResponse
```

After adding a controller listener to the kraftcontroller, the issue was resolved.
```
listeners:
  controller:
    authentication:
      type: plain
      jaasConfig:
        secretRef: credential
    tls:
      enabled: true
```