### PR TITLE
Change namespace from 'confluent-certs' to 'confluent'

### DIFF
--- a/security/using-cert-manager/cert-manager/self-signed/kustomization.yaml
+++ b/security/using-cert-manager/cert-manager/self-signed/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: confluent-certs
+namespace: confluent
 
 configurations:
 - kustomizeconfig.yaml


### PR DESCRIPTION
issue with namespace.
changed from confluent-certs to confluent