### PR TITLE
Add USM Agent Prometheus monitoring example

### DIFF
--- a/hybrid/usmagent/monitoring/README.md
+++ b/hybrid/usmagent/monitoring/README.md
@@ -1,0 +1,76 @@
+## Monitor USM Agent with Prometheus
+
+This example demonstrates how to set up Prometheus monitoring for USM Agent using a PodMonitor.
+
+### Pre-requisite
+
+- Deploy Confluent For Kubernetes (CFK) Operator
+- Deploy USM Agent using any of the auth examples ([basic_auth](../basic_auth), [tls](../tls), [mtls](../mtls))
+- [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) installed in the cluster (for PodMonitor support)
+
+```
+export TUTORIAL_HOME=<Tutorial directory>/hybrid/usmagent/monitoring
+```
+
+### Create Prometheus credentials secret
+
+The monitoring endpoint (port 9910) uses the **same authentication** as the dataplane listener.
+When basic auth is configured on the USMAgent, Prometheus must provide credentials to scrape metrics.
+
+```
+kubectl create secret generic usm-prometheus-creds \
+  --from-literal=username=<usm-agent-basic-auth-username> \
+  --from-literal=password=<usm-agent-basic-auth-password> \
+  -n confluent
+```
+
+The username and password must match the USM Agent basic auth credentials (the same credentials configured in the USMAgent CR under `spec.authentication.basic.secretRef`).
+
+> **Note:** If USMAgent is deployed in plaintext mode (no authentication), you can skip this step and remove the `basicAuth` section from the PodMonitor.
+
+### Deploy PodMonitor
+
+```
+kubectl apply -f $TUTORIAL_HOME/podmonitor.yaml
+```
+
+### Verify metrics are accessible
+
+Port-forward to the monitoring port:
+
+```
+USM_POD=$(kubectl get pods -n confluent -l app=usm-agent -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward $USM_POD 9910:9910 -n confluent &
+```
+
+Without auth (should return 401 when basic auth is enabled):
+
+```
+curl -s http://localhost:9910/stats/prometheus
+# Output: User authentication failed. Missing username and password.
+```
+
+With auth (should return Prometheus metrics):
+
+```
+curl -s -u "<username>:<password>" http://localhost:9910/stats/prometheus | head -10
+```
+
+### Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `envoy_cluster_upstream_rq{envoy_response_code="200"}` | Healthy telemetry flow to Confluent Cloud |
+| `envoy_cluster_upstream_rq{envoy_response_code="400"}` | Cluster not yet registered in Confluent Cloud (expected before registration) |
+| `envoy_cluster_upstream_rq{envoy_response_code="401"}` | Authentication failure — check CCloud or CP credentials |
+| `envoy_cluster_upstream_rq{envoy_response_code="503"}` | Connectivity issue to Confluent Cloud — check PrivateLink or network config |
+
+### Recommended Grafana Dashboard
+
+USM Agent uses Envoy internally. Import the [Envoy Proxy Monitoring dashboard (ID: 23239)](https://grafana.com/grafana/dashboards/23239-envoy-proxy-monitoring/) for a pre-built visualization.
+
+### Important Notes
+
+- **Authentication required:** The monitoring port mirrors the dataplane authentication. When basic auth is configured on the USMAgent, Prometheus must provide the same credentials.
+- **PodMonitor required:** Port 9910 binds to localhost inside the pod. Use a PodMonitor (not ServiceMonitor) since the port is not exposed via a Kubernetes Service.
+- **Plaintext mode:** When USMAgent has no authentication configured, Prometheus can scrape without credentials — remove the `basicAuth` section from the PodMonitor.

--- a/hybrid/usmagent/monitoring/podmonitor.yaml
+++ b/hybrid/usmagent/monitoring/podmonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: usm-agent-monitor
+  namespace: confluent
+spec:
+  selector:
+    matchLabels:
+      app: usm-agent
+  podMetricsEndpoints:
+    - port: monitoring
+      path: /stats/prometheus
+      interval: 30s
+      basicAuth:
+        username:
+          name: usm-prometheus-creds
+          key: username
+        password:
+          name: usm-prometheus-creds
+          key: password


### PR DESCRIPTION
## What

Adds a Prometheus monitoring example for USM Agent at `hybrid/usmagent/monitoring/`.

## Why

USM Agent exposes Envoy metrics on port 9910, but there's no example showing how to scrape them. The key undocumented behavior is that **the monitoring port requires the same basic auth as the dataplane listener** — Prometheus must provide credentials when basic auth is configured on the USMAgent CR.

## Files Added

- `hybrid/usmagent/monitoring/README.md` — setup steps, key metrics, Grafana dashboard recommendation
- `hybrid/usmagent/monitoring/podmonitor.yaml` — PodMonitor CR with basicAuth config

## Key Details

- Port 9910 mirrors dataplane authentication (basic auth required when configured)
- Port 9910 binds to localhost — PodMonitor works, ServiceMonitor won't
- Key metric: `envoy_cluster_upstream_rq` grouped by `envoy_response_code` (200=healthy, 401=auth failure, 503=connectivity issue)
- Recommended Grafana dashboard: Envoy Proxy Monitoring (ID: 23239)

## Testing

Validated on EKS cluster with CFK 3.1.x and USM Agent 1.0.0:
- Without auth → `User authentication failed. Missing username and password.`
- With auth → 1838 metric lines returned successfully
- Key metrics confirmed present

🤖 Generated with [Claude Code](https://claude.com/claude-code)