### PR TITLE
Update quickstart KRaft examples to CFK 3.2 and CP 8.2

### DIFF
--- a/quickstart-deploy/confluent-platform-kraft.yaml
+++ b/quickstart-deploy/confluent-platform-kraft.yaml
@@ -7,7 +7,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
   dependencies:
     metricsClient:
@@ -28,7 +28,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -40,7 +40,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-server-connect:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -54,7 +54,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-ksqldb-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -66,7 +66,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -100,7 +100,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-schema-registry:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -111,7 +111,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-kafka-rest:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/confluent-platform-kraft.yaml
+++ b/quickstart-deploy/confluent-platform-kraft.yaml
@@ -6,9 +6,12 @@ metadata:
 spec:
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
+  dependencies:
+    metricsClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Kafka
@@ -20,10 +23,12 @@ spec:
     kRaftController:
       clusterRef:
         name: kraftcontroller
+    metricsClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -34,8 +39,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-server-connect:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: confluentinc/cp-server-connect:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -48,8 +53,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-ksqldb-server:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: confluentinc/cp-ksqldb-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -60,8 +65,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-enterprise-control-center:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -72,6 +77,19 @@ spec:
     connect:
     - name: connect
       url: http://connect.confluent.svc.cluster.local:8083
+    kafka:
+      bootstrapEndpoint: http://kafka.confluent.svc.cluster.local:9071
+    prometheusClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
+    alertManagerClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9093
+  services:
+    prometheus:
+      image: confluentinc/cp-enterprise-prometheus:2.5.0
+      pvc:
+        dataVolumeCapacity: 10Gi
+    alertmanager:
+      image: confluentinc/cp-enterprise-alertmanager:2.5.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: SchemaRegistry
@@ -81,8 +99,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-schema-registry:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: confluentinc/cp-schema-registry:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -92,8 +110,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-kafka-rest:7.9.0
-    init: confluentinc/confluent-init-container:2.11.0
+    application: confluentinc/cp-kafka-rest:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/kraft-quickstart/confluent-platform-c3++.yaml
+++ b/quickstart-deploy/kraft-quickstart/confluent-platform-c3++.yaml
@@ -7,7 +7,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
   dependencies:
     metricsClient:
@@ -22,7 +22,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 100Gi
   dependencies:
     kRaftController:
@@ -40,7 +40,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-server-connect:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -54,7 +54,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-ksqldb-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -66,7 +66,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -100,7 +100,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-schema-registry:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -111,7 +111,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-kafka-rest:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/kraft-quickstart/confluent-platform-c3++.yaml
+++ b/quickstart-deploy/kraft-quickstart/confluent-platform-c3++.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
   dependencies:
     metricsClient:
@@ -21,8 +21,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 100Gi
   dependencies:
     kRaftController:
@@ -39,8 +39,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-server-connect:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-server-connect:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -53,8 +53,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-ksqldb-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-ksqldb-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -65,8 +65,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-enterprise-control-center-next-gen:2.2.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -85,11 +85,11 @@ spec:
       url: http://controlcenter.confluent.svc.cluster.local:9093
   services:
     prometheus:
-      image: confluentinc/cp-enterprise-prometheus:2.2.0
+      image: confluentinc/cp-enterprise-prometheus:2.5.0
       pvc:
         dataVolumeCapacity: 10Gi
     alertmanager:
-      image: confluentinc/cp-enterprise-alertmanager:2.2.0
+      image: confluentinc/cp-enterprise-alertmanager:2.5.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: SchemaRegistry
@@ -99,8 +99,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-schema-registry:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-schema-registry:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -110,8 +110,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-kafka-rest:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-kafka-rest:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/kraft-quickstart/confluent-platform.yaml
+++ b/quickstart-deploy/kraft-quickstart/confluent-platform.yaml
@@ -6,9 +6,12 @@ metadata:
 spec:
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
+  dependencies:
+    metricsClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Kafka
@@ -18,13 +21,15 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-server:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 100Gi
   dependencies:
     kRaftController:
       clusterRef:
         name: kraftcontroller
+    metricsClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: Connect
@@ -34,8 +39,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-server-connect:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-server-connect:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -48,8 +53,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-ksqldb-server:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-ksqldb-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -60,8 +65,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-enterprise-control-center:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
+    init: confluentinc/confluent-init-container:3.2.0
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -72,6 +77,19 @@ spec:
     connect:
     - name: connect
       url: http://connect.confluent.svc.cluster.local:8083
+    kafka:
+      bootstrapEndpoint: http://kafka.confluent.svc.cluster.local:9071
+    prometheusClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9090
+    alertManagerClient:
+      url: http://controlcenter.confluent.svc.cluster.local:9093
+  services:
+    prometheus:
+      image: confluentinc/cp-enterprise-prometheus:2.5.0
+      pvc:
+        dataVolumeCapacity: 10Gi
+    alertmanager:
+      image: confluentinc/cp-enterprise-alertmanager:2.5.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: SchemaRegistry
@@ -81,8 +99,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-schema-registry:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-schema-registry:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -92,8 +110,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-kafka-rest:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: confluentinc/cp-kafka-rest:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/kraft-quickstart/confluent-platform.yaml
+++ b/quickstart-deploy/kraft-quickstart/confluent-platform.yaml
@@ -7,7 +7,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
   dependencies:
     metricsClient:
@@ -22,7 +22,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 100Gi
   dependencies:
     kRaftController:
@@ -40,7 +40,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-server-connect:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071
@@ -54,7 +54,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-ksqldb-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -66,7 +66,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-enterprise-control-center-next-gen:2.5.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dataVolumeCapacity: 10Gi
   dependencies:
     schemaRegistry:
@@ -100,7 +100,7 @@ spec:
   replicas: 3
   image:
     application: confluentinc/cp-schema-registry:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
 ---
 apiVersion: platform.confluent.io/v1beta1
 kind: KafkaRestProxy
@@ -111,7 +111,7 @@ spec:
   replicas: 1
   image:
     application: confluentinc/cp-kafka-rest:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.confluent.svc.cluster.local:8081

--- a/quickstart-deploy/kraft-quickstart/kraftbroker_controller.yaml
+++ b/quickstart-deploy/kraft-quickstart/kraftbroker_controller.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -18,8 +18,8 @@ metadata:
 spec:
   dataVolumeCapacity: 10G
   image:
-    application: docker.io/confluentinc/cp-server:7.9.1
-    init: confluentinc/confluent-init-container:2.11.1
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.2.0
   replicas: 3
   dependencies:
     kRaftController:

--- a/quickstart-deploy/kraft-quickstart/kraftbroker_controller.yaml
+++ b/quickstart-deploy/kraft-quickstart/kraftbroker_controller.yaml
@@ -7,7 +7,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
 ---
 apiVersion: platform.confluent.io/v1beta1
@@ -19,7 +19,7 @@ spec:
   dataVolumeCapacity: 10G
   image:
     application: docker.io/confluentinc/cp-server:8.2.0
-    init: confluentinc/confluent-init-container:3.2.0
+    init: confluentinc/confluent-init-container:3.2.2
   replicas: 3
   dependencies:
     kRaftController:


### PR DESCRIPTION
- Bump cp-server / cp-server-connect / cp-ksqldb-server / cp-schema-registry / cp-kafka-rest to 8.2.0
- Bump confluent-init-container to 3.2.0
- Bump cp-enterprise-control-center-next-gen / prometheus / alertmanager to 2.5.0
- Migrate confluent-platform-kraft.yaml and kraft-quickstart/confluent-platform.yaml from legacy cp-enterprise-control-center to cp-enterprise-control-center-next-gen, including the metricsClient / prometheusClient / alertManagerClient deps and services.prometheus / services.alertmanager blocks
- ZK-based quickstart files are intentionally left at 7.9.0 since CP 8.x is KRaft-only