### PR TITLE
docs: fix observer image name in observer-container READMEs

### DIFF
--- a/observer-container/README.md
+++ b/observer-container/README.md
@@ -87,7 +87,7 @@ spec:
   services:
     observer:
       # Observer container image
-      image: "confluentinc/confluent-operator-observer:latest"
+      image: "confluentinc/confluent-observer-container:latest"
       
       # Authentication for observer endpoints
       authentication:

--- a/observer-container/tls/README.md
+++ b/observer-container/tls/README.md
@@ -148,7 +148,7 @@ certs/
 spec:
   services:
     observer:
-      image: us.gcr.io/cc-devel/confluent-operator-observer:latest
+      image: us.gcr.io/cc-devel/confluent-observer-container:latest
       authentication:
         type: mtls
       tls:
@@ -161,7 +161,7 @@ spec:
 spec:
   services:
     observer:
-      image: us.gcr.io/cc-devel/confluent-operator-observer:latest
+      image: us.gcr.io/cc-devel/confluent-observer-container:latest
       authentication:
         type: mtls
       tls:
@@ -182,7 +182,7 @@ spec:
 spec:
   services:
     observer:
-      image: us.gcr.io/cc-devel/confluent-operator-observer:latest
+      image: us.gcr.io/cc-devel/confluent-observer-container:latest
       logLevel: debug
       authentication:
         type: mtls


### PR DESCRIPTION
## Summary
- Replace `confluent-operator-observer` with `confluent-observer-container` in `observer-container/README.md` and `observer-container/tls/README.md`.
- `confluent-observer-container` is the actual released image name on Docker Hub; `confluent-operator-observer` was never published. The wrong name leaked into these READMEs likely because the observer is built/bundled inside the `confluent-operator` codebase.

## Context
Filed under INC-11002 ("CFK observer image naming discrepancy blocks customer guidance"). A sibling PR fixes the same wording in the CFK repo. Docs team is doing the equivalent sweep in the docs codebase.

## Test plan
- [ ] Docs-only change.
- [ ] grep confirms no remaining `confluent-operator-observer` references in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)