### PR TITLE
Add hot-reload canary (Gateway) RBAC rules to operator clusterrole 

### DIFF
--- a/security/kubernetes-rbac/cfk-only-cluster-role-rolebinding.yaml
+++ b/security/kubernetes-rbac/cfk-only-cluster-role-rolebinding.yaml
@@ -109,8 +109,7 @@ rules:
   - watch # needed for nonnamespaced deployments
 # Required for CFK 3.3.0+.
 # Hot-reload canary (Gateway): operator creates/observes Jobs to validate new
-# config before promoting it into the shared ConfigMap. See
-# pkg/workflow/hotreload.
+# config before promoting it into the shared ConfigMap.
 - apiGroups:
   - batch
   resources:

--- a/security/kubernetes-rbac/cfk-only-cluster-role-rolebinding.yaml
+++ b/security/kubernetes-rbac/cfk-only-cluster-role-rolebinding.yaml
@@ -107,6 +107,31 @@ rules:
   - get
   - list # needed for nonnamespaced deployments
   - watch # needed for nonnamespaced deployments
+# Required for CFK 3.3.0+.
+# Hot-reload canary (Gateway): operator creates/observes Jobs to validate new
+# config before promoting it into the shared ConfigMap. See
+# pkg/workflow/hotreload.
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# Also required for CFK 3.3.0+. pods/log is a subresource and needs its own
+# rule. Used by the canary workflow to capture the last ~50 log lines from a
+# failed canary pod into the Gateway's HotReload status condition.
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 cluster-role-rolebinding:
   yaml:
 ---

--- a/security/kubernetes-rbac/cluster-role-rolebinding.yaml
+++ b/security/kubernetes-rbac/cluster-role-rolebinding.yaml
@@ -115,8 +115,7 @@ rules:
   - watch # needed for nonnamespaced deployments
 # Required for CFK 3.3.0+.
 # Hot-reload canary (Gateway): operator creates/observes Jobs to validate new
-# config before promoting it into the shared ConfigMap. See
-# pkg/workflow/hotreload.
+# config before promoting it into the shared ConfigMap.
 - apiGroups:
   - batch
   resources:

--- a/security/kubernetes-rbac/cluster-role-rolebinding.yaml
+++ b/security/kubernetes-rbac/cluster-role-rolebinding.yaml
@@ -113,6 +113,31 @@ rules:
   - get
   - list # needed for nonnamespaced deployments
   - watch # needed for nonnamespaced deployments
+# Required for CFK 3.3.0+.
+# Hot-reload canary (Gateway): operator creates/observes Jobs to validate new
+# config before promoting it into the shared ConfigMap. See
+# pkg/workflow/hotreload.
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# Also required for CFK 3.3.0+. pods/log is a subresource and needs its own
+# rule. Used by the canary workflow to capture the last ~50 log lines from a
+# failed canary pod into the Gateway's HotReload status condition.
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/security/kubernetes-rbac/namespaced-rolebinding.yaml
+++ b/security/kubernetes-rbac/namespaced-rolebinding.yaml
@@ -119,6 +119,30 @@ rules:
   - namespaces
   verbs:
   - get
+# Required for CFK 3.3.0+.
+# Hot-reload canary (Gateway): operator creates/observes Jobs to validate new
+# config before promoting it into the shared ConfigMap.
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+# Also required for CFK 3.3.0+. pods/log is a subresource and needs its own
+# rule. Used by the canary workflow to capture the last ~50 log lines from a
+# failed canary pod into the Gateway's HotReload status condition.
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 # Change the service account subject to one that exists in your namespace
 # Change the namespace to your namespace


### PR DESCRIPTION
CFK 3.3.0 added batch/jobs and pods/log rules to the operator ClusterRole for the Hot-reload canary (Gateway) validation workflow. Customers using a custom cluster role hit "jobs.batch is forbidden" on CFK 3.3.0+.

Add these rules to the kubernetes-rbac ClusterRole examples so custom-role users have the required permissions.  