### PR TITLE
CPCG-799: Correcting JAAS key name for gateway oauth examples

### DIFF
--- a/gateway/authswap-mtls-sasl-oauth/README.md
+++ b/gateway/authswap-mtls-sasl-oauth/README.md
@@ -76,7 +76,7 @@ kubectl create secret generic file-store-config --from-literal=separator="/" -n 
 - Create JAAS template secret for gateway to Kafka cluster connection.
 ```
 kubectl create secret generic oauth-jaas \
-  --from-literal=oauth-jaas.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
+  --from-literal=oauth-jass.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
   -n confluent
 ```
 

--- a/gateway/authswap-sasl-oauth-sasl-oauth/README.md
+++ b/gateway/authswap-sasl-oauth-sasl-oauth/README.md
@@ -65,14 +65,14 @@ kubectl create secret generic file-store-config --from-literal=separator="/" -n 
 - Create the JAAS config secret used by the Gateway to validate inbound client tokens. No client credentials are needed here - the Gateway only verifies the token signature/claims against the IdP's JWKS endpoint.
 ```
 kubectl create secret generic client-oauth-jaas \
-  --from-literal=oauth-jaas.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;' \
+  --from-literal=oauth-jass.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;' \
   -n confluent
 ```
 
 - Create the JAAS template secret used by the Gateway for the swapped connection to the Kafka cluster.
 ```
 kubectl create secret generic oauth-jaas \
-  --from-literal=oauth-jaas.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
+  --from-literal=oauth-jass.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
   -n confluent
 ```
 

--- a/gateway/authswap-sasl-scram-sasl-oauth/README.md
+++ b/gateway/authswap-sasl-scram-sasl-oauth/README.md
@@ -78,7 +78,7 @@ kubectl create secret generic scram-admin-credentials \
 - Create JAAS template secret for gateway to Kafka cluster connection.
 ```
 kubectl create secret generic oauth-jaas \
-  --from-literal=oauth-jaas.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
+  --from-literal=oauth-jass.conf='org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s";' \
   -n confluent
 ```
 


### PR DESCRIPTION
Currently, examples guide the customers to create a secret with oauth-jaas.conf as key for oauth.
For all passthrough configs, CFK operator expects oauth-ja**ss**.conf as a key.
This prevents Gateway CR for coming up with below exceptions:
```required at least one of the keys [oauth-jass.conf] in secretRef oauth-jaas for authtype oauth```

This PR fixes that by correcting the key in the steps. 